### PR TITLE
api-swaps-per-chain-from-covalent

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "gas-refund:prod:compute-gas-refund-save-db": "node scripts/gas-refund-program/computeGasRefund.js",
     "gas-refund:compute-merkle-tree-save-db": "patch-package && NODE_ENV=development ts-node scripts/gas-refund-program/computeMerkleTree",
     "gas-refund:compute-merkle-tree-save-file": "patch-package && SAVE_FILE=true SKIP_CHECKS=true NODE_ENV=development ts-node scripts/gas-refund-program/computeMerkleTree",
-    "test": "jest"
+    "test": "jest",
+    "debug-grp": "patch-package && NODE_ENV=development node --inspect=9230 -r ts-node/register scripts/gas-refund-program/computeGasRefund.ts",
+    "debug-seed-data": "NODE_ENV=development node -r ts-node/register scripts/gas-refund-program/transactions-indexing/temp-seed.ts"
   },
   "husky": {
     "hooks": {

--- a/scripts/gas-refund-program/computeGasRefund.ts
+++ b/scripts/gas-refund-program/computeGasRefund.ts
@@ -30,8 +30,10 @@ async function startComputingGasRefundAllChains() {
       `LOCK TABLE "${GasRefundParticipation.tableName}" IN ACCESS EXCLUSIVE MODE;`,
     );
 
+    const chains = GRP_SUPPORTED_CHAINS.filter(chain => chain !== 250)
+
     return Promise.allSettled(
-      GRP_SUPPORTED_CHAINS.map(async chainId => {
+      chains.map(async chainId => {
         const lastEpochProcessed = await GasRefundParticipation.max<
           number,
           GasRefundParticipation
@@ -49,9 +51,15 @@ async function startComputingGasRefundAllChains() {
           'cannot compute refund data for epoch < genesis_epoch',
         );
 
+        // for (
+        //   let epoch = startEpoch;
+        //   epoch <= epochInfo.getCurrentEpoch();
+        //   epoch++
+        // ) {
+        // todo: Revert this - for now just test on one epoch
         for (
-          let epoch = startEpoch;
-          epoch <= epochInfo.getCurrentEpoch();
+          let epoch = 10;
+          epoch < 11;
           epoch++
         ) {
           const { startCalcTime, endCalcTime } =

--- a/scripts/gas-refund-program/computeGasRefund.ts
+++ b/scripts/gas-refund-program/computeGasRefund.ts
@@ -30,10 +30,8 @@ async function startComputingGasRefundAllChains() {
       `LOCK TABLE "${GasRefundParticipation.tableName}" IN ACCESS EXCLUSIVE MODE;`,
     );
 
-    const chains = GRP_SUPPORTED_CHAINS.filter(chain => chain !== 250)
-
     return Promise.allSettled(
-      chains.map(async chainId => {
+      GRP_SUPPORTED_CHAINS.map(async chainId => {
         const lastEpochProcessed = await GasRefundParticipation.max<
           number,
           GasRefundParticipation

--- a/scripts/gas-refund-program/persistance/db-persistance.ts
+++ b/scripts/gas-refund-program/persistance/db-persistance.ts
@@ -31,6 +31,7 @@ export const fetchPendingGasRefundData = async ({
   return pendingEpochDataByAddress;
 };
 
+// todo: remove this temp function - used while testing/comparing new data
 export const fetchPendingGasRefundDataCovalent = async ({
   chainId,
   epoch,
@@ -73,6 +74,7 @@ export async function fetchVeryLastTimestampProcessed({
 
 export const writePendingEpochData = async (
   pendingEpochGasRefundData: PendingEpochGasRefundData[],
+  // todo: remove after changing over to covalent - have just one data source
   pendingEpochGasRefundDataCovalent: PendingEpochGasRefundData[],
 ) => {
   await GasRefundParticipation.bulkCreate(pendingEpochGasRefundData, {
@@ -93,6 +95,7 @@ export const writePendingEpochData = async (
     ],
   });
 
+  // todo: remove after changing over to covalent - have just one data source
   await GasRefundParticipationCovalent.bulkCreate(pendingEpochGasRefundDataCovalent, {
     updateOnDuplicate: [
       'accumulatedGasUsedPSP',

--- a/scripts/gas-refund-program/transactions-indexing/successful-swap-tx-indexing.ts
+++ b/scripts/gas-refund-program/transactions-indexing/successful-swap-tx-indexing.ts
@@ -46,6 +46,7 @@ export async function computeSuccessfulSwapsTxFeesRefund({
     `swapTracker start indexing between ${startTimestamp} and ${endTimestamp}`,
   );
 
+  // todo: remove `accPendingGasRefundByAddressCOVALENT` and `fetchPendingGasRefundDataCovalent({ chainId, epoch })` after testing/comparing data
   const [accPendingGasRefundByAddress, accPendingGasRefundByAddressCOVALENT, veryLastTimestampProcessed] =
     await Promise.all([
       fetchPendingGasRefundData({ chainId, epoch }),
@@ -68,9 +69,9 @@ export async function computeSuccessfulSwapsTxFeesRefund({
   const covalentTXs = Test.readStoredCovalentTXs(chainId, epoch, startTimestamp, endTimestamp)
 
   for (
-    let _startTimestampSlice = _startTimestamp, i = 0;
-    _startTimestampSlice < endTimestamp && i < 100000000000;
-    _startTimestampSlice += SLICE_DURATION, i++
+    let _startTimestampSlice = _startTimestamp;
+    _startTimestampSlice < endTimestamp;
+    _startTimestampSlice += SLICE_DURATION
   ) {
     const _endTimestampSlice = Math.min(
       _startTimestampSlice + SLICE_DURATION,
@@ -246,7 +247,7 @@ export async function computeSuccessfulSwapsTxFeesRefund({
       updatedPendingGasRefundDataByAddress[address] = pendingGasRefundDatum;
     });
 
-    // todo: swapover to this code once happy and scrap above
+    // todo: swapover to this code once happy, replacing above `swapsWithGasUsed.forEach` block
     filteredTXs.forEach(covalentSwap => {
       const address = covalentSwap.txOrigin;
       const startOfHourUnixTms = startOfHourSec(+covalentSwap.timestamp);

--- a/scripts/gas-refund-program/transactions-indexing/successful-swap-tx-indexing.ts
+++ b/scripts/gas-refund-program/transactions-indexing/successful-swap-tx-indexing.ts
@@ -3,10 +3,11 @@ import { HistoricalPrice, TxFeesByAddress } from '../types';
 import { BigNumber } from 'bignumber.js';
 import {
   fetchPendingGasRefundData,
+  fetchPendingGasRefundDataCovalent,
   fetchVeryLastTimestampProcessed,
   writePendingEpochData,
 } from '../persistance/db-persistance';
-import { getSwapsForAccounts, getSwapsPerNetwork } from './swaps-subgraph';
+import { getSwapsForAccounts, getSwapsPerNetwork, CovalentSwap } from './swaps-subgraph';
 import {
   getRefundPercent,
   PendingEpochGasRefundData,
@@ -16,6 +17,7 @@ import { getPSPStakesHourlyWithinInterval } from '../staking';
 import * as _ from 'lodash';
 import { constructSameDayPrice } from '../token-pricing/psp-chaincurrency-pricing';
 import { ONE_HOUR_SEC, startOfHourSec } from '../utils';
+import * as Test from '../../../src/test'
 
 // empirically set to maximise on processing time without penalising memory and fetching constraigns
 // @FIXME: fix swaps subgraph pagination to always stay on safest spot
@@ -44,9 +46,10 @@ export async function computeSuccessfulSwapsTxFeesRefund({
     `swapTracker start indexing between ${startTimestamp} and ${endTimestamp}`,
   );
 
-  const [accPendingGasRefundByAddress, veryLastTimestampProcessed] =
+  const [accPendingGasRefundByAddress, accPendingGasRefundByAddressCOVALENT, veryLastTimestampProcessed] =
     await Promise.all([
       fetchPendingGasRefundData({ chainId, epoch }),
+      fetchPendingGasRefundDataCovalent({ chainId, epoch }),
       fetchVeryLastTimestampProcessed({ chainId, epoch }),
     ]);
 
@@ -56,16 +59,18 @@ export async function computeSuccessfulSwapsTxFeesRefund({
   );
 
   // get all txs for the epoch,
-  const covalentTXs = await getSwapsPerNetwork({
-    startTimestamp: _startTimestamp,
-    endTimestamp,
-    chainId
-  })
+  // todo: reinstate this - reading from disk is just for testing
+  // const covalentTXs = await getSwapsPerNetwork({
+  //   startTimestamp: _startTimestamp,
+  //   endTimestamp,
+  //   chainId
+  // })
+  const covalentTXs = Test.readStoredCovalentTXs(chainId, epoch, startTimestamp, endTimestamp)
 
   for (
-    let _startTimestampSlice = _startTimestamp;
-    _startTimestampSlice < endTimestamp;
-    _startTimestampSlice += SLICE_DURATION
+    let _startTimestampSlice = _startTimestamp, i = 0;
+    _startTimestampSlice < endTimestamp && i < 100000000000;
+    _startTimestampSlice += SLICE_DURATION, i++
   ) {
     const _endTimestampSlice = Math.min(
       _startTimestampSlice + SLICE_DURATION,
@@ -104,7 +109,7 @@ export async function computeSuccessfulSwapsTxFeesRefund({
     );
 
     // alternatively can slice requests over different sub intervals matching different stakers subset but we'd be refetching same data
-    // todo: this will be replaced with covalent tx data
+    // todo: keep while comparing data - this will be replaced with covalent tx data
     const swaps = await getSwapsForAccounts({
       startTimestamp: _startTimestampSlice,
       endTimestamp: _endTimestampSlice,
@@ -113,6 +118,12 @@ export async function computeSuccessfulSwapsTxFeesRefund({
     });
 
     const txsOfStakers = covalentTXs.filter(({txOrigin}) => stakersAddress.includes(txOrigin))
+
+    // we already got all covalent txs for the epoch in one go, so here filter by timestamp just to fit in with old code
+    const filteredTXs = txsOfStakers.filter(tx => {
+      const timestamp = +tx.timestamp
+      return timestamp >= _startTimestampSlice && timestamp <= _endTimestampSlice
+    })
 
     // todo: go through all transactions (lifting off gas used) and getting stakes at each time - eg `fetchStakesPerUser?`
 
@@ -139,6 +150,7 @@ export async function computeSuccessfulSwapsTxFeesRefund({
     );
 
     const updatedPendingGasRefundDataByAddress: TxFeesByAddress = {};
+    const updatedPendingGasRefundDataByAddressCOVALENT: TxFeesByAddress = {};
 
     swapsWithGasUsed.forEach(swap => {
       const address = swap.txOrigin;
@@ -234,15 +246,121 @@ export async function computeSuccessfulSwapsTxFeesRefund({
       updatedPendingGasRefundDataByAddress[address] = pendingGasRefundDatum;
     });
 
+    // todo: swapover to this code once happy and scrap above
+    filteredTXs.forEach(covalentSwap => {
+      const address = covalentSwap.txOrigin;
+      const startOfHourUnixTms = startOfHourSec(+covalentSwap.timestamp);
+      const startOfNextHourUnixTms = startOfHourSec(
+        +covalentSwap.timestamp + ONE_HOUR_SEC,
+      );
+
+      const stakesStartOfHour = stakesByHour[startOfHourUnixTms];
+      const stakesStartOfNextHour = stakesByHour[startOfNextHourUnixTms];
+
+      assert(
+        stakesStartOfHour,
+        'stakes at beginning of hour should be defined',
+      );
+      assert(
+        stakesStartOfNextHour,
+        'stakes at beginning of next hour should be defined',
+      );
+
+      const swapperAcc = accPendingGasRefundByAddressCOVALENT[address];
+
+      const swapperStake = BigNumber.max(
+        stakesStartOfHour[address] || 0,
+        stakesStartOfNextHour[address] || 0,
+      );
+
+      if (swapperStake.isZero()) {
+        // as we fetcher swaps for all stakers all hourly splitted intervals we sometimes fell into this case
+        logger.warn(`could not retrieve any stake for staker ${address}`);
+        return;
+      }
+
+      const pspRateSameDay = findSameDayPrice(+covalentSwap.timestamp);
+
+      assert(
+        pspRateSameDay,
+        `could not retrieve psp/chaincurrency same day rate for swap at ${covalentSwap.timestamp}`,
+      );
+
+      // different from before - now we use original gas price (as covalent is already correct opposed to graph)
+      const currGasUsed = new BigNumber(+covalentSwap.txGasUsed);
+      const accumulatedGasUsed = currGasUsed.plus(
+        swapperAcc?.accumulatedGasUsed || 0,
+      );
+
+      const currGasUsedChainCur = currGasUsed.multipliedBy(
+        +covalentSwap.txGasPrice,
+      ); // in wei
+
+      const accumulatedGasUsedChainCurrency = currGasUsedChainCur.plus(
+        swapperAcc?.accumulatedGasUsedChainCurrency || 0,
+      );
+
+      const currGasFeePSP = currGasUsedChainCur.dividedBy(pspRateSameDay);
+
+      const accumulatedGasUsedPSP = currGasFeePSP.plus(
+        swapperAcc?.accumulatedGasUsedPSP || 0,
+      );
+
+      const totalStakeAmountPSP = swapperStake.toFixed(0); // @todo irrelevant?
+      const refundPercent = getRefundPercent(totalStakeAmountPSP);
+      assert(
+        refundPercent,
+        `Logic Error: failed to find refund percent for ${address}`,
+      );
+      const currRefundedAmountPSP = currGasFeePSP.multipliedBy(refundPercent);
+
+      const accRefundedAmountPSP = currRefundedAmountPSP.plus(
+        swapperAcc?.refundedAmountPSP || 0,
+      );
+
+      const pendingGasRefundDatumCOVALENT: PendingEpochGasRefundData = {
+        epoch,
+        address,
+        chainId,
+        accumulatedGasUsedPSP: accumulatedGasUsedPSP.toFixed(0),
+        accumulatedGasUsed: accumulatedGasUsed.toFixed(0),
+        accumulatedGasUsedChainCurrency:
+          accumulatedGasUsedChainCurrency.toFixed(0),
+        firstBlock: swapperAcc?.lastBlock || covalentSwap.blockNumber,
+        lastBlock: covalentSwap.blockNumber,
+        totalStakeAmountPSP,
+        refundedAmountPSP: accRefundedAmountPSP.toFixed(0),
+        firstTx: swapperAcc?.firstTx || covalentSwap.txHash,
+        lastTx: covalentSwap.txHash,
+        firstTimestamp: swapperAcc?.firstTimestamp || +covalentSwap.timestamp,
+        lastTimestamp: +covalentSwap.timestamp,
+        numTx: (swapperAcc?.numTx || 0) + 1,
+        isCompleted: false,
+      };
+
+      accPendingGasRefundByAddressCOVALENT[address] = pendingGasRefundDatumCOVALENT;
+      updatedPendingGasRefundDataByAddressCOVALENT[address] = pendingGasRefundDatumCOVALENT;
+    });
+
     const updatedGasRefundDataList = Object.values(
       updatedPendingGasRefundDataByAddress,
+    );
+    const updatedGasRefundDataListCOVALENT = Object.values(
+      updatedPendingGasRefundDataByAddressCOVALENT,
     );
 
     if (updatedGasRefundDataList.length > 0) {
       logger.info(
         `updating ${updatedGasRefundDataList.length} pending gas refund data`,
       );
-      await writePendingEpochData(updatedGasRefundDataList);
+      await writePendingEpochData(updatedGasRefundDataList, []);
+    }
+
+    if (updatedGasRefundDataList.length > 0) {
+      logger.info(
+        `updating ${updatedGasRefundDataList.length} pending gas refund data`,
+      );
+      await writePendingEpochData([], updatedGasRefundDataListCOVALENT);
     }
   }
 

--- a/scripts/gas-refund-program/transactions-indexing/successful-swap-tx-indexing.ts
+++ b/scripts/gas-refund-program/transactions-indexing/successful-swap-tx-indexing.ts
@@ -17,7 +17,7 @@ import { getPSPStakesHourlyWithinInterval } from '../staking';
 import * as _ from 'lodash';
 import { constructSameDayPrice } from '../token-pricing/psp-chaincurrency-pricing';
 import { ONE_HOUR_SEC, startOfHourSec } from '../utils';
-import * as Test from '../../../src/test'
+import * as Test from './temp-seed'
 
 // empirically set to maximise on processing time without penalising memory and fetching constraigns
 // @FIXME: fix swaps subgraph pagination to always stay on safest spot

--- a/scripts/gas-refund-program/transactions-indexing/swaps-subgraph.ts
+++ b/scripts/gas-refund-program/transactions-indexing/swaps-subgraph.ts
@@ -5,7 +5,7 @@ import {
   CHAIN_ID_MAINNET,
   CHAIN_ID_POLYGON,
 } from '../../../src/lib/constants';
-import { thegraphClient } from '../data-providers-clients';
+import { thegraphClient, covalentClient } from '../data-providers-clients';
 import { sliceCalls } from '../utils';
 import { assert } from 'ts-essentials';
 
@@ -97,4 +97,117 @@ interface SwapData {
   txGasPrice: string;
   blockNumber: number;
   timestamp: string;
+}
+
+type GetSwapsForNetwork = Omit<GetSwapsForAccountsInput, 'accounts'>
+
+namespace Covalent {
+
+  export interface Transaction {
+    from_address: string
+    to_address: string
+    tx_hash: string
+    block_height: number;
+    block_signed_at: string;
+    gas_offered: number,
+    gas_spent: number,
+    gas_price: number,
+    fees_paid: number,
+    gas_quote: number,
+    gas_quote_rate: number,
+    // ... and a lot more
+  }
+  export interface AddressTransactionsResponse {
+    data: {
+      data: {
+        address: string
+        chain_id: string
+        quote_currency: string
+        items: Transaction[]
+        pagination: {
+          has_more: boolean
+          page_number: number
+          page_size: number
+          total_count: null
+        }
+      }
+    }
+  }
+}
+
+export async function getSwapsPerNetwork({
+  startTimestamp,
+  endTimestamp,
+  chainId,
+}: GetSwapsForNetwork): Promise<SwapData[]> {
+
+  const AUGUSTUS = '0xDEF171Fe48CF0115B1d80b88dc8eAB59176FEe57'
+
+  const covalentAddressToSwap = (txCov: Covalent.Transaction): SwapData => ({
+    txHash: txCov.tx_hash,
+    txOrigin: txCov.from_address,
+    txGasPrice: txCov.gas_spent.toString(),
+    // todo: should be string to match subgraph data, but type is numeric
+    blockNumber: txCov.block_height,
+    // convert time to unixtime - seconds
+    timestamp: (new Date(txCov.block_signed_at).getTime() / 1000).toString(),
+  })
+
+  // filter out smart contract wallets
+  const filterTXs = (txCov: Covalent.Transaction): boolean => {
+    return txCov.to_address.toLowerCase() === AUGUSTUS.toLowerCase()
+  }
+
+  // todo: add safety margin to both start/end and de-dup later
+  const { COVALENT_API_KEY } = process.env
+  const path = (page: number) => {
+
+    // these query params should be calculated for each request (since time sensitive)
+    const startSecondsAgo = Math.floor((new Date().getTime()) / 1000) - startTimestamp
+    const duration = endTimestamp - startTimestamp
+    /**
+     * NOTE: for this to work, we must only query historic data.
+     * if start limit + duration is not less than now, we'll get
+     * live data which may change across paginations since it is
+     * still forming.
+     */
+    if (endTimestamp > Date.now()) {
+      throw new Error('only query historic data')
+    }
+
+    return `/${chainId}/address/${AUGUSTUS}/transactions_v2/?key=${COVALENT_API_KEY}&no-logs=true&page-number=${page}&page-size=1000&block-signed-at-limit=${startSecondsAgo}&block-signed-at-span=${duration}`
+  }
+
+
+  let items: SwapData[] = []
+  let hasMore = true
+  let page = 1
+  let calls = 0
+  var timeAllStart = new Date();
+
+  // todo: better would be to first call the end point with page-size=0 just to get the total number of items, and then construct many request promises and run concurrently - currently this isn't possible due to a flaw in the covalent api
+
+  while (hasMore) {
+    const route = path(page)
+    var timeRequestStart = new Date();
+    const { data } = await covalentClient.get(route)
+
+    const { data: { pagination: { has_more }, items: receivedItems }} = data
+
+    hasMore = has_more
+    page++
+
+    items = [...items, ...receivedItems.filter(filterTXs).map(covalentAddressToSwap)]
+
+    calls++
+    const timeRequestEnd = new Date();
+    const secondsForRequest: number = (+timeRequestEnd - +timeRequestStart) / 1000;
+
+    console.log({calls, route, secondsForRequest})
+  }
+  const timeAllEnd = new Date();
+  const millisecondsElapsed: number = +timeAllEnd - +timeAllStart;
+  console.log(`time to get all requests`, millisecondsElapsed / 1000)
+
+  return items
 }

--- a/scripts/gas-refund-program/transactions-indexing/temp-seed.ts
+++ b/scripts/gas-refund-program/transactions-indexing/temp-seed.ts
@@ -3,8 +3,8 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 import * as fs from 'fs'
 
-import * as Swaps from '../scripts/gas-refund-program/transactions-indexing/swaps-subgraph'
-import * as GRP from './lib/gas-refund'
+import * as Swaps from './swaps-subgraph'
+import * as GRP from '../../../src/lib/gas-refund'
 
 const testDataPath = (chainId: number, epoch: number, startTimestamp: number, endTimestamp: number): string => `seed-data/covalent_chain:${chainId}_epoch:${epoch}_${startTimestamp}-${endTimestamp}.json`
 

--- a/src/models/GasRefundParticipationCovalent.ts
+++ b/src/models/GasRefundParticipationCovalent.ts
@@ -1,0 +1,98 @@
+/**
+ * Temp file/model just while testing covalent sourced data side by side
+ * with existing subgraph data.
+ */
+// todo: delete this model
+
+import {
+  Table,
+  Model,
+  Column,
+  AllowNull,
+  PrimaryKey,
+  DataType,
+  AutoIncrement,
+  createIndexDecorator,
+  Index,
+} from 'sequelize-typescript';
+import { EpochGasRefundData } from '../lib/gas-refund';
+
+import {
+  DataType_ADDRESS,
+  DataType_KECCAK256_HASHED_VALUE,
+} from '../lib/sql-data-types';
+
+const compositeIndex = createIndexDecorator({
+  name: 'epochgasrefundcovalent_epoch_address_chain',
+  type: 'UNIQUE',
+  unique: true,
+});
+
+@Table
+export class GasRefundParticipationCovalent extends Model<EpochGasRefundData> {
+  @PrimaryKey
+  @AutoIncrement
+  @Column(DataType.INTEGER)
+  id: number;
+
+  @compositeIndex
+  @Column(DataType.SMALLINT)
+  epoch: number;
+
+  @compositeIndex
+  @Column(DataType_ADDRESS)
+  address: string;
+
+  @compositeIndex
+  @Column(DataType.INTEGER)
+  chainId: number;
+
+  @Column(DataType.BOOLEAN)
+  isCompleted: boolean;
+
+  @Column(DataType.INTEGER)
+  firstBlock: number; // @debug
+
+  @Index
+  @Column(DataType.INTEGER)
+  lastBlock: number;
+
+  @Column(DataType.INTEGER)
+  firstTimestamp: number; // @debug
+
+  @Index
+  @Column(DataType.INTEGER)
+  lastTimestamp: number;
+
+  @Column(DataType_KECCAK256_HASHED_VALUE)
+  firstTx: string; // @debug
+
+  @Column(DataType_KECCAK256_HASHED_VALUE)
+  lastTx: string; // @debug
+
+  @Column(DataType.SMALLINT)
+  numTx: number; // @debug
+
+  @Column(DataType.BIGINT)
+  accumulatedGasUsed: string; // @debug
+
+  @Column(DataType.DECIMAL)
+  accumulatedGasUsedChainCurrency: string; // @debug
+
+  @Column(DataType.DECIMAL)
+  accumulatedGasUsedPSP: string;
+
+  @AllowNull(true)
+  @Column(DataType.DECIMAL)
+  totalStakeAmountPSP: string; // @debug
+
+  @AllowNull(true)
+  @Column(DataType.DECIMAL)
+  refundedAmountPSP: string;
+
+  @AllowNull(true)
+  @Column({
+    type: DataType.ARRAY(DataType_KECCAK256_HASHED_VALUE),
+  })
+  merkleProofs: string[];
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -52,16 +52,9 @@ const test = async () => {
     startTimestamp: 1649073600,
     endTimestamp: 1650283200,
   }
-  console.log(process.env.COVALENT_API_KEY)
-  const swaps = await Swaps.getSwapsPerNetwork(swapRetrievalParams)
-  console.log('swap count', swaps.length)
 
-  fs.writeFileSync('covalent-swaps_BSC_10.json', JSON.stringify(swaps))
-
-  // ftm has an issue on covalent just now
-  const chains = GRP.GRP_SUPPORTED_CHAINS.filter(chain => chain !== 250)
   // get test data for each chain and store it in a seed dir for use elsewhere
-  chains.forEach(async chainId => {
+  GRP.GRP_SUPPORTED_CHAINS.filter(chain => chain !== 137).forEach(async chainId => {
     const { startTimestamp, endTimestamp } =swapRetrievalParams
     const swaps = await Swaps.getSwapsPerNetwork({
       startTimestamp,

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,58 @@
+
+import * as dotenv from 'dotenv';
+dotenv.config();
+import * as fs from 'fs'
+
+import * as Swaps from '../scripts/gas-refund-program/transactions-indexing/swaps-subgraph'
+
+const test = async () => {
+  /*
+  chainId: 1,
+  startTimestamp: 1649073280,
+  endTimestamp: 1649073600,
+
+  chainId: 1,
+  startTimestamp: 1649073600,
+  endTimestamp: 1649095200,
+
+  EPOCH
+  chainId: 1,
+  startTimestamp: 1647864000,
+  endTimestamp: 1649073600,
+
+  EPOCH
+  chainId: 1,
+  startTimestamp: 1650283200,
+  endTimestamp: 1650295443,
+
+
+  FTM:
+  Epoch 9
+  chainId: 250,
+  startTimestamp: 1647864000,
+  endTimestamp: 1649073600,
+
+  Epoch 10
+  chainId: 250,
+  startTimestamp: 1649073600,
+  endTimestamp: 1650283200,
+
+  Epoch 11
+  chainId: 250,
+  startTimestamp: 1649073600,
+  endTimestamp: 1650283200,
+  */
+ // epoch 10
+  const swapRetrievalParams = {
+    chainId: 56,
+    startTimestamp: 1649073600,
+    endTimestamp: 1650283200,
+  }
+  console.log(process.env.COVALENT_API_KEY)
+  const swaps = await Swaps.getSwapsPerNetwork(swapRetrievalParams)
+  console.log('swap count', swaps.length)
+
+  fs.writeFileSync('covalent-swaps_BSC_10.json', JSON.stringify(swaps))
+}
+
+test()


### PR DESCRIPTION
replace graph with covalent for TXs.

- [x] get data alongside existing data
- [x] ensure TXs are de-duped
- [x] add safe margin when querying covalent to ensure all TXs are fetched.
- [x] test with fantom once fixed on covalent's side
- [ ] integrate with forward plan 

testing:
- pull down and drop the `GasRefundParticipations` table
- `yarn run debug-seed-data` this will pull covalent data and save it to json (temporary measure while building the script)
- `yarn run debug-grp`
- check the db and compare GasRefundParticipations with GasRefundParticipationCovalents

```
SELECT grp."chainId", grp.refunds as graphRefunds, grpc.refunds as covalentRefunds, ROUND(grpc.refunds * 100.0 / grp.refunds, 1)-100 as refundChange, grp.txs as graphTXs, grpc.txs as covalentTXs, ROUND(grpc.txs * 100.0 / grp.txs, 1)-100 as txChange
FROM
(SELECT SUM ("refundedAmountPSP") as refunds, SUM ("numTx") as txs, "chainId" FROM "GasRefundParticipations" GROUP BY "chainId") grp
join 
(SELECT SUM ("refundedAmountPSP") as refunds, SUM ("numTx") as txs, "chainId" FROM "GasRefundParticipationCovalents" GROUP BY "chainId") grpc
on grpc."chainId" = grp."chainId"
```
![image](https://user-images.githubusercontent.com/6588340/164285919-f02ff94d-f79a-4fae-aa83-c79d1392c666.png)

