### PR TITLE
feat/gas-refund: compute refund based on avg last 24h token prices

### DIFF
--- a/scripts/gas-refund-program/token-pricing/psp-chaincurrency-pricing.ts
+++ b/scripts/gas-refund-program/token-pricing/psp-chaincurrency-pricing.ts
@@ -9,7 +9,6 @@ import {
   sampleDailyAvgPricesStartOfDay,
 } from './coingecko';
 import { startOfDayMilliSec } from '../utils';
-import memoize from 'lodash/memoize';
 
 const fetchHistoricalPriceCoingeckoCached = pMemoize(
   fetchHistoricalPriceCoingecko,
@@ -94,7 +93,7 @@ const constructSameDayPriceResolver = (
 const constructLast24hAvgPriceResolver = (
   prices: HistoricalTokenUsdPrices,
 ): PriceResolverFn => {
-  return memoize(function resolveLast24hAvgPrice(unixTime: number) {
+  return function resolveLast24hAvgPrice(unixTime: number) {
     const avgChainCurrencyPrice = computeDailyAvgLast24h(
       prices.chainCurrencyHistoricalPrices,
       unixTime * 1000,
@@ -109,7 +108,7 @@ const constructLast24hAvgPriceResolver = (
       chainPrice: avgChainCurrencyPrice,
       pspPrice: avgPSPPrice,
     };
-  });
+  };
 };
 
 export const constructPriceResolver = (

--- a/scripts/gas-refund-program/token-pricing/psp-chaincurrency-pricing.ts
+++ b/scripts/gas-refund-program/token-pricing/psp-chaincurrency-pricing.ts
@@ -62,6 +62,7 @@ export async function fetchDailyPSPChainCurrencyRate({
 
 export type PriceResolverFn = (unixtime: number) => PricesAtTimestamp;
 
+// Deprecated algo but still used for older epoch (<11)
 const constructSameDayPriceResolver = (
   prices: HistoricalTokenUsdPrices,
 ): PriceResolverFn => {
@@ -90,6 +91,7 @@ const constructSameDayPriceResolver = (
   };
 };
 
+// computes moving average prices for last 24h 
 const constructLast24hAvgPriceResolver = (
   prices: HistoricalTokenUsdPrices,
 ): PriceResolverFn => {

--- a/scripts/gas-refund-program/transactions-indexing/successful-swap-tx-indexing.ts
+++ b/scripts/gas-refund-program/transactions-indexing/successful-swap-tx-indexing.ts
@@ -15,7 +15,7 @@ import { getTransactionGasUsed } from '../staking/covalent';
 import { getPSPStakesHourlyWithinInterval } from '../staking';
 import * as _ from 'lodash';
 import { ONE_HOUR_SEC, startOfHourSec } from '../utils';
-import { FindSameDayPrice } from '../token-pricing/psp-chaincurrency-pricing';
+import { PriceResolverFn } from '../token-pricing/psp-chaincurrency-pricing';
 import GRPSystemGuardian, { MAX_USD_ADDRESS_BUDGET } from '../system-guardian';
 
 // empirically set to maximise on processing time without penalising memory and fetching constraigns
@@ -27,13 +27,13 @@ export async function computeSuccessfulSwapsTxFeesRefund({
   startTimestamp,
   endTimestamp,
   epoch,
-  findSameDayPrice,
+  resolvePrice,
 }: {
   chainId: number;
   startTimestamp: number;
   endTimestamp: number;
   epoch: number;
-  findSameDayPrice: FindSameDayPrice;
+  resolvePrice: PriceResolverFn;
 }): Promise<void> {
   const logger = global.LOGGER(
     `GRP:TRANSACTION_FEES_INDEXING: epoch=${epoch}, chainId=${chainId}`,
@@ -174,7 +174,7 @@ export async function computeSuccessfulSwapsTxFeesRefund({
         return;
       }
 
-      const currencyRate = findSameDayPrice(+swap.timestamp);
+      const currencyRate = resolvePrice(+swap.timestamp);
 
       assert(
         currencyRate,


### PR DESCRIPTION
# Help for regression tests
Run
-  `yarn gas-refund:dev:compute-gas-refund-save-db`
- `GRP_EPOCH=9 yarn gas-refund:prod:compute-gas-refund-save-db`
- `GRP_EPOCH=10 yarn gas-refund:prod:compute-gas-refund-save-db`

Inspect GasRefundDistributions verify than merkleRoots matches with contracts/prod:
Epoch 9:
https://api.paraswap.io/staking/gas-refund/describe?epoch=9&network=1
https://api.paraswap.io/staking/gas-refund/describe?epoch=9&network=56
https://api.paraswap.io/staking/gas-refund/describe?epoch=9&network=137
https://api.paraswap.io/staking/gas-refund/describe?epoch=9&network=250

Epoch 10:
https://api.paraswap.io/staking/gas-refund/describe?epoch=10&network=1
https://api.paraswap.io/staking/gas-refund/describe?epoch=10&network=56
https://api.paraswap.io/staking/gas-refund/describe?epoch=10&network=137
https://api.paraswap.io/staking/gas-refund/describe?epoch=10&network=250

