### PR TITLE
fix/gas-refund: stable script start time

### DIFF
--- a/scripts/gas-refund-program/common.ts
+++ b/scripts/gas-refund-program/common.ts
@@ -12,6 +12,7 @@ export async function init(options?: Params) {
   await epochInfo.getEpochInfo();
 }
 
+export const SCRIPT_START_TIME_SEC = Math.round(Date.now() / 1000);
 export const OFFSET_CALC_TIME = 5 * 60; // delay to ensure that all third parties providers are synced
 
 export async function resolveEpochCalcTimeInterval(epoch: number): Promise<{
@@ -26,11 +27,9 @@ export async function resolveEpochCalcTimeInterval(epoch: number): Promise<{
   ]);
   const epochEndTime = epochStartTime + epochDuration; // safer than getEpochEndCalcTime as it fails for current epoch
 
-  const nowSec = Math.round(Date.now() / 1000);
-
   return {
     startCalcTime: epochStartTime,
-    endCalcTime: Math.min(nowSec - OFFSET_CALC_TIME, epochEndTime),
-    isEpochEnded: nowSec > epochEndTime + OFFSET_CALC_TIME,
+    endCalcTime: Math.min(SCRIPT_START_TIME_SEC - OFFSET_CALC_TIME, epochEndTime),
+    isEpochEnded: SCRIPT_START_TIME_SEC >= epochEndTime + OFFSET_CALC_TIME,
   };
 }

--- a/scripts/gas-refund-program/common.ts
+++ b/scripts/gas-refund-program/common.ts
@@ -12,7 +12,7 @@ export async function init(options?: Params) {
   await epochInfo.getEpochInfo();
 }
 
-export const SCRIPT_START_TIME_SEC = Math.round(Date.now() / 1000);
+export const SCRIPT_START_TIME_SEC = Math.round(Date.now() / 1000); // stable script start time to align stakes and transactions fetching time intervals
 export const OFFSET_CALC_TIME = 5 * 60; // delay to ensure that all third parties providers are synced
 
 export async function resolveEpochCalcTimeInterval(epoch: number): Promise<{

--- a/scripts/gas-refund-program/staking/stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/stakes-tracker.ts
@@ -8,7 +8,7 @@ import {
   GasRefundSafetyModuleStartEpoch,
   GasRefundSPSPStakesAlgoFlipEpoch,
 } from '../../../src/lib/gas-refund';
-import { OFFSET_CALC_TIME } from '../common';
+import { OFFSET_CALC_TIME, SCRIPT_START_TIME_SEC } from '../common';
 import { getLatestTransactionTimestamp } from '../persistance/db-persistance';
 import SafetyModuleStakesTracker from './safety-module-stakes-tracker';
 import SPSPStakesTracker from './spsp-stakes-tracker';
@@ -37,7 +37,7 @@ export default class StakesTracker {
       latestTxTimestamp ||
       (await epochInfo.getEpochStartCalcTime(GasRefundSafetyModuleStartEpoch));
 
-    const endTime = Math.round(Date.now() / 1000) - OFFSET_CALC_TIME;
+    const endTime = SCRIPT_START_TIME_SEC - OFFSET_CALC_TIME;
 
     const [startBlockSPSP, startBlockSM, endBlock] = await Promise.all([
       blockInfo.getBlockAfterTimeStamp(startTimeSPSP),


### PR DESCRIPTION
This solves a problem happening on current epoch if stakes loading takes consequent time we might miss some staking events.
Therefore transactions scanned between `end_of_stakes_fetching_time` and `end_of_transactions_scanning_time` might be wrongly refunded. This PR aligns those 2 events in time by relying on same script start time.