### PR TITLE
feat/gas-refund-unit-tests

### DIFF
--- a/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
+++ b/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
@@ -78,7 +78,6 @@ describe('SafetyModuleStakesTracker', () => {
       const account = '0x88f81b95eae67461b2d687343d36852f87409a7b';
 
       const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
-
       const minHeldDuringVirtualLockup =
         tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
 
@@ -96,8 +95,13 @@ describe('SafetyModuleStakesTracker', () => {
       const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
       const minHeldDuringVirtualLockup =
         tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
-      expect(spotStake.isEqualTo(minHeldDuringVirtualLockup)).toBeFalsy();
+
       expect(minHeldDuringVirtualLockup.isLessThan(spotStake)).toBeTruthy();
+
+      expect(spotStake.toFixed(0)).toBe('1364657414057644135201');
+      expect(minHeldDuringVirtualLockup.toFixed(0)).toBe(
+        '994128705008224339309',
+      );
     });
   });
 });

--- a/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
+++ b/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
@@ -103,5 +103,21 @@ describe('SafetyModuleStakesTracker', () => {
         '994128705008224339309',
       );
     });
+
+    test('had some stake and withdrew it all  within [t-lockup_window, t[ and did a new tx at t', () => {
+      // redeem: https://etherscan.io/tx/0xb1ab807d5939ccec01adfbe74528abbe54278f0a26a98a05d3592093612395cd
+      // swap:  https://etherscan.io/tx/0xb4a441329d92eabf6db2467e1b7d2d83196c2ee3caf8755a7f9c3896e0afbeda
+
+      const txTimestamp = 1656472361;
+      const account = '0xfc44a13ea1a98166ffc0719f83b5f3ee2759c03f';
+
+      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
+
+      const minHeldDuringVirtualLockup =
+        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+
+      expect(spotStake.isEqualTo(minHeldDuringVirtualLockup)).toBeTruthy();
+      expect(spotStake.isZero()).toBeTruthy();
+    });
   });
 });

--- a/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
+++ b/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
@@ -8,10 +8,18 @@ describe('SafetyModuleStakesTracker', () => {
   describe('snashot test for backward compat', () => {
     let tracker: SafetyModuleStakesTracker;
     const startBlock = 14567000;
+    const endBlock = startBlock + 10000;
+    const startTimestamp = 1649715553;
+    const endTimestamp = 1649851552;
 
     beforeAll(async () => {
       tracker = new SafetyModuleStakesTracker();
-      tracker.setBlockBoundary(startBlock + 1, startBlock + 10000);
+      tracker.setBlockBoundary({
+        startBlock: startBlock + 1,
+        endBlock,
+        startTimestamp,
+        endTimestamp,
+      });
       await tracker.loadStakes();
     });
 

--- a/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
+++ b/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
@@ -50,7 +50,7 @@ describe('SafetyModuleStakesTracker', () => {
     });
   });
 
-  describe('virtual lockup', () => {
+  describe('virtual lockup - only stakes held for 7d preceding a transaction are taken into account', () => {
     const startBlock = 14942024;
     const startTimestamp = 1654917473;
 
@@ -70,21 +70,24 @@ describe('SafetyModuleStakesTracker', () => {
       await tracker.loadStakes();
     });
 
-    test('had stake for more than lockup_window and did a tx', () => {
+    test('account had stake for more than lockup_window and did a tx, whole stake is taken into account', () => {
       // stake : https://etherscan.io/tx/0x6ca776bf1de66ca31385a5da967bc432b4042c928aeffee3562208f735982759
       // swap : https://etherscan.io/tx/0x450e4bec3f2977caddc4a191c43db761147ca53059183287c9e337ab6741e17a
 
       const txTimestamp = 1655660833;
       const account = '0x88f81b95eae67461b2d687343d36852f87409a7b';
 
-      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
-      const minHeldDuringVirtualLockup =
+      const actualStakeAtT = tracker.computeStakedPSPBalance(
+        account,
+        txTimestamp,
+      );
+      const virtuallyLockedStakeAtT =
         tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
 
-      expect(spotStake.isEqualTo(minHeldDuringVirtualLockup)).toBeTruthy();
+      expect(actualStakeAtT.isEqualTo(virtuallyLockedStakeAtT)).toBeTruthy();
     });
 
-    test('had some stakes and staked more within [t-lockup_window, t[ and did a new tx at t', () => {
+    test('account had some stakes and staked more within [t-lockup_window, t[ and did a new tx at t, take into account only part of stake held for last 7d', () => {
       // first staked: 0xc413fded33705a1877211ee1a3f88800eb8c63a11fb11298c094e0255b2fee4f - ~1000 PSP - at t - 10d
       // second staked: 0xf29c2c99da6d4e44ae7d2b21bf935a5a94b651827ed1264375f243394ec7c906 - ~7 PSP   - at t - 4d
       // then did tx: 0x1c7a1bd67e4db53f622f8d9e1c22a6e4ff6dc152ffc9ca89aef1729aa2a3da95 - at t
@@ -92,32 +95,37 @@ describe('SafetyModuleStakesTracker', () => {
       const txTimestamp = 1657252834;
       const account = '0x4532280a66a0c1c709f7e0c40b14b4dea83253c1';
 
-      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
-      const minHeldDuringVirtualLockup =
+      const actualStakeAtT = tracker.computeStakedPSPBalance(
+        account,
+        txTimestamp,
+      );
+      const virtuallyLockedStakeAtT =
         tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
 
-      expect(minHeldDuringVirtualLockup.isLessThan(spotStake)).toBeTruthy();
+      expect(virtuallyLockedStakeAtT.isLessThan(actualStakeAtT)).toBeTruthy();
 
-      expect(spotStake.toFixed(0)).toBe('1364657414057644135201');
-      expect(minHeldDuringVirtualLockup.toFixed(0)).toBe(
-        '994128705008224339309',
-      );
+      expect(actualStakeAtT.toFixed(0)).toBe('1364657414057644135201');
+      expect(virtuallyLockedStakeAtT.toFixed(0)).toBe('994128705008224339309');
     });
 
-    test('had some stake and withdrew it all  within [t-lockup_window, t[ and did a new tx at t', () => {
+    // this test is meant as a safe guard. On some buggy iterations the algo was picking future stakes.
+    test('had some stake and withdrew it all  within [t-lockup_window, t[ and did a new tx at t, should not take into account any stake', () => {
       // redeem: https://etherscan.io/tx/0xb1ab807d5939ccec01adfbe74528abbe54278f0a26a98a05d3592093612395cd
       // swap:  https://etherscan.io/tx/0xb4a441329d92eabf6db2467e1b7d2d83196c2ee3caf8755a7f9c3896e0afbeda
 
       const txTimestamp = 1656472361;
       const account = '0xfc44a13ea1a98166ffc0719f83b5f3ee2759c03f';
 
-      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
+      const actualStakeAtT = tracker.computeStakedPSPBalance(
+        account,
+        txTimestamp,
+      );
 
-      const minHeldDuringVirtualLockup =
+      const virtuallyLockedStakeAtT =
         tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
 
-      expect(spotStake.isEqualTo(minHeldDuringVirtualLockup)).toBeTruthy();
-      expect(spotStake.isZero()).toBeTruthy();
+      expect(actualStakeAtT.isEqualTo(virtuallyLockedStakeAtT)).toBeTruthy();
+      expect(actualStakeAtT.isZero()).toBeTruthy();
     });
   });
 });

--- a/__tests__/gas-refund-program/sps-stakes-tracker.ts
+++ b/__tests__/gas-refund-program/sps-stakes-tracker.ts
@@ -142,4 +142,112 @@ describe('SpspStakesTracker', () => {
       });
     });
   });
+  describe('virtual lockup', () => {
+    const startBlock = 14305200;
+    const startTimestamp = 1646192162;
+
+    const endBlock = 15123160;
+    const endTimestamp = 1657566578;
+
+    let tracker: SPSPStakesTracker;
+
+    beforeAll(async () => {
+      tracker = new SPSPStakesTracker().setBlockBoundary({
+        startBlock,
+        startTimestamp,
+        endBlock,
+        endTimestamp,
+      });
+
+      await tracker.loadStakes();
+    });
+
+    test('had stake for more than lockup_window and did a tx', () => {
+      // enterWithPermit: https://etherscan.io/tx/0x76ebb2fcb750e16f086c9e75a1364d7f5355a283f49eda6c2845819df6d57b91
+      // swap : https://polygonscan.com/tx/0x185ad8ff97fd92eedaa045722d65f487478887051e9402e2f1da699ffa92876f
+      const txTimestamp = 1657396621;
+      const account = '0x88f81b95eae67461b2d687343d36852f87409a7b';
+
+      const spotStake = tracker
+        .computeStakedPSPBalance(account, txTimestamp)
+        .toFixed(0);
+      const minHeldDuringVirtualLockup = tracker
+        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
+        .toFixed(0);
+
+      expect(spotStake).toBe(minHeldDuringVirtualLockup);
+    });
+
+    test('had no stake and staked within [t-lockup_window, t[ and did a new tx at t', () => {
+      // enter : https://etherscan.io/tx/0x746c71e8bb678c26e58ef2c03e49adc4b4b1a6208a723772dad867da2cca8a87
+      // swap : https://etherscan.io/tx/0x62aebdcfe527375fdfa0e87cdde482557febb330afe38b21c3143df936b621ae
+
+      const txTimestamp = 1656366935;
+      const account = '0x17134276ce356f3bacad4e2b23222d9a088ac248';
+
+      const spotStake = tracker
+        .computeStakedPSPBalance(account, txTimestamp)
+        .toFixed(0);
+      const minHeldDuringVirtualLockup = tracker
+        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
+        .toFixed(0);
+
+      expect(spotStake).toBe('14596156936477148188887');
+      expect(minHeldDuringVirtualLockup).toBe('0');
+    });
+
+    test('had some stake and staked more within [t-lockup_window, t[ and did a new tx at t', () => {
+      // enter: https://etherscan.io/tx/0xdeed3257737726d250c5be4529f862f32d325b842b92cd179b1c4cae8b1930d4
+      // swap: https://etherscan.io/tx/0xc9f96b1de35449efb4a64c1d2e1bbc008e95c3e4429c7bd4976087ce14917c95
+
+      const txTimestamp = 1656430446;
+      const account = '0x5577933afc0522c5ee71115df61512f49da0543e';
+
+      const spotStake = tracker
+        .computeStakedPSPBalance(account, txTimestamp)
+        .toFixed(0);
+      const minHeldDuringVirtualLockup = tracker
+        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
+        .toFixed(0);
+
+      expect(spotStake).toBe('619217648752360328978270');
+      expect(minHeldDuringVirtualLockup).toBe('516526358541823114384937');
+    });
+
+    test('had some stake and withdrew a portion within [t-lockup_window, t[ and did a new tx at t', () => {
+      // leave: https://etherscan.io/tx/0x8123fabee2397ccd9a7071b0d58e0ef8fbe88bbbde3ee35131129c1b47064415
+      // swap: https://etherscan.io/tx/0x7c32bf8707788598969d941e74df1a947be85a6482e3e779bc7113c5f013f0d1
+
+      const txTimestamp = 1649168528;
+      const account = '0x05537ac27aef02ee087ae859a73f2cc5fe15c798';
+
+      const spotStake = tracker
+        .computeStakedPSPBalance(account, txTimestamp)
+        .toFixed(0);
+      const minHeldDuringVirtualLockup = tracker
+        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
+        .toFixed(0);
+
+      expect(spotStake).toBe(minHeldDuringVirtualLockup);
+      expect(spotStake).not.toBe('0');
+    });
+
+    test('had some stake and withdrew it all before tx', () => {
+      // leave: https://etherscan.io/tx/0x4211f53fa0f3cc931774d5b97aeaf118f0be0b862564819709d1cc3b9cb99b69
+      // swap: https://etherscan.io/tx/0x06e55919991c52887b0958f21388505ff2585cf87939b5cb9cdf0bf7529b044b
+
+      const txTimestamp = 1656515184;
+      const account = '0x1d1ae55be3b5b4a0220eed418403cb3b2755e2b4';
+
+      const spotStake = tracker
+        .computeStakedPSPBalance(account, txTimestamp)
+        .toFixed(0);
+      const minHeldDuringVirtualLockup = tracker
+        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
+        .toFixed(0);
+
+      expect(spotStake).toBe(minHeldDuringVirtualLockup);
+      expect(spotStake).toBe('0');
+    });
+  });
 });

--- a/__tests__/gas-refund-program/sps-stakes-tracker.ts
+++ b/__tests__/gas-refund-program/sps-stakes-tracker.ts
@@ -168,14 +168,12 @@ describe('SpspStakesTracker', () => {
       const txTimestamp = 1657396621;
       const account = '0x88f81b95eae67461b2d687343d36852f87409a7b';
 
-      const spotStake = tracker
-        .computeStakedPSPBalance(account, txTimestamp)
-        .toFixed(0);
-      const minHeldDuringVirtualLockup = tracker
-        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
-        .toFixed(0);
+      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
 
-      expect(spotStake).toBe(minHeldDuringVirtualLockup);
+      const minHeldDuringVirtualLockup =
+        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+
+      expect(spotStake.isEqualTo(minHeldDuringVirtualLockup)).toBeTruthy();
     });
 
     test('had no stake and staked within [t-lockup_window, t[ and did a new tx at t', () => {
@@ -185,15 +183,13 @@ describe('SpspStakesTracker', () => {
       const txTimestamp = 1656366935;
       const account = '0x17134276ce356f3bacad4e2b23222d9a088ac248';
 
-      const spotStake = tracker
-        .computeStakedPSPBalance(account, txTimestamp)
-        .toFixed(0);
-      const minHeldDuringVirtualLockup = tracker
-        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
-        .toFixed(0);
+      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
 
-      expect(spotStake).toBe('14596156936477148188887');
-      expect(minHeldDuringVirtualLockup).toBe('0');
+      const minHeldDuringVirtualLockup =
+        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+
+      expect(spotStake.toFixed(0)).toBe('14596156936477148188887');
+      expect(minHeldDuringVirtualLockup.toFixed(0)).toBe('0');
     });
 
     test('had some stake and staked more within [t-lockup_window, t[ and did a new tx at t', () => {
@@ -203,15 +199,16 @@ describe('SpspStakesTracker', () => {
       const txTimestamp = 1656430446;
       const account = '0x5577933afc0522c5ee71115df61512f49da0543e';
 
-      const spotStake = tracker
-        .computeStakedPSPBalance(account, txTimestamp)
-        .toFixed(0);
-      const minHeldDuringVirtualLockup = tracker
-        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
-        .toFixed(0);
+      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
 
-      expect(spotStake).toBe('619217648752360328978270');
-      expect(minHeldDuringVirtualLockup).toBe('516526358541823114384937');
+      const minHeldDuringVirtualLockup =
+        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+
+      expect(minHeldDuringVirtualLockup.isLessThan(spotStake)).toBeTruthy();
+      expect(spotStake.toFixed(0)).toBe('619217648752360328978270');
+      expect(minHeldDuringVirtualLockup.toFixed(0)).toBe(
+        '516526358541823114384937',
+      );
     });
 
     test('had some stake and withdrew a portion within [t-lockup_window, t[ and did a new tx at t', () => {
@@ -221,15 +218,13 @@ describe('SpspStakesTracker', () => {
       const txTimestamp = 1649168528;
       const account = '0x05537ac27aef02ee087ae859a73f2cc5fe15c798';
 
-      const spotStake = tracker
-        .computeStakedPSPBalance(account, txTimestamp)
-        .toFixed(0);
-      const minHeldDuringVirtualLockup = tracker
-        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
-        .toFixed(0);
+      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
 
-      expect(spotStake).toBe(minHeldDuringVirtualLockup);
-      expect(spotStake).not.toBe('0');
+      const minHeldDuringVirtualLockup =
+        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+
+      expect(spotStake.isEqualTo(minHeldDuringVirtualLockup)).toBeTruthy();
+      expect(spotStake.toFixed(0)).not.toBe('0');
     });
 
     test('had some stake and withdrew it all before tx', () => {
@@ -239,15 +234,13 @@ describe('SpspStakesTracker', () => {
       const txTimestamp = 1656515184;
       const account = '0x1d1ae55be3b5b4a0220eed418403cb3b2755e2b4';
 
-      const spotStake = tracker
-        .computeStakedPSPBalance(account, txTimestamp)
-        .toFixed(0);
-      const minHeldDuringVirtualLockup = tracker
-        .computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp)
-        .toFixed(0);
+      const spotStake = tracker.computeStakedPSPBalance(account, txTimestamp);
 
-      expect(spotStake).toBe(minHeldDuringVirtualLockup);
-      expect(spotStake).toBe('0');
+      const minHeldDuringVirtualLockup =
+        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+
+      expect(spotStake.isEqualTo(minHeldDuringVirtualLockup)).toBeTruthy();
+      expect(spotStake.isZero()).toBeTruthy();
     });
   });
 });

--- a/__tests__/gas-refund-program/sps-stakes-tracker.ts
+++ b/__tests__/gas-refund-program/sps-stakes-tracker.ts
@@ -10,13 +10,23 @@ jest.setTimeout(5 * 60 * 1000);
 describe('SpspStakesTracker', () => {
   describe('snashot test for backward compat', () => {
     let tracker: SPSPStakesTracker;
-    let startBlock = 14652905;
-    let endBlock = 14722785;
+    const startBlock = 14652905;
+    const startTimestamp = 1650877705;
+
+    const endBlock = 14722785;
+    const endTimestamp = 1651829555;
 
     beforeAll(async () => {
       tracker = new SPSPStakesTracker();
 
-      await tracker.setBlockBoundary(startBlock, endBlock).loadStakes();
+      await tracker
+        .setBlockBoundary({
+          startBlock,
+          endBlock,
+          startTimestamp,
+          endTimestamp,
+        })
+        .loadStakes();
     });
 
     test('Init state', () => {
@@ -39,12 +49,17 @@ describe('SpspStakesTracker', () => {
     let lateSPSPTracker: SPSPStakesTracker;
     let atObservationTracker: SPSPStakesTracker;
 
-    let observationTimestamp = 1651829438; // is matching startBlockAtObservationTracker
+    const startBlockEarlyTracker = 14652905;
+    const startTimestapEarlyTracker = 1650877705;
 
-    let startBlockEarlyTracker = 14652905;
-    let startBlockLateTracker = 14699930;
-    let startBlockAtObservationTracker = 14722775; // matching observationTimestamp
-    let endBlockAllTrackers = startBlockAtObservationTracker + 1; // later than all but doesn't really matter much in future. Just after oberservation is fine
+    const startBlockLateTracker = 14699930;
+    const startTimestampLateTracker = 1651516627;
+
+    const startBlockAtObservationTracker = 14722775; // matching observationTimestamp
+    const observationTimestamp = 1651829438; // is matching startBlockAtObservationTracker
+
+    const endBlockAllTrackers = startBlockAtObservationTracker + 1; // later than all but doesn't really matter much in future. Just after oberservation is fine
+    const endTimestamp = 1651829444;
 
     assert(
       startBlockEarlyTracker < startBlockLateTracker &&
@@ -60,13 +75,28 @@ describe('SpspStakesTracker', () => {
 
       await Promise.all([
         earlySPSPTracker
-          .setBlockBoundary(startBlockEarlyTracker, endBlockAllTrackers)
+          .setBlockBoundary({
+            startBlock: startBlockEarlyTracker,
+            endBlock: endBlockAllTrackers,
+            startTimestamp: startTimestapEarlyTracker,
+            endTimestamp,
+          })
           .loadStakes(),
         lateSPSPTracker
-          .setBlockBoundary(startBlockLateTracker, endBlockAllTrackers)
+          .setBlockBoundary({
+            startBlock: startBlockLateTracker,
+            endBlock: endBlockAllTrackers,
+            startTimestamp: startTimestampLateTracker,
+            endTimestamp,
+          })
           .loadStakes(),
         atObservationTracker
-          .setBlockBoundary(startBlockAtObservationTracker, endBlockAllTrackers)
+          .setBlockBoundary({
+            startBlock: startBlockAtObservationTracker,
+            startTimestamp: observationTimestamp,
+            endBlock: endBlockAllTrackers,
+            endTimestamp,
+          })
           .loadStakes(),
       ]);
     });

--- a/scripts/gas-refund-program/computeMerkleTree.ts
+++ b/scripts/gas-refund-program/computeMerkleTree.ts
@@ -26,7 +26,6 @@ const logger = global.LOGGER('GRP:COMPUTE_MERKLE_TREE');
 const skipCheck = process.env.SKIP_CHECKS === 'true';
 const saveFile = process.env.SAVE_FILE === 'true';
 
-// @FIXME: should cap amount distributed to stakers to 30k
 export async function computeAndStoreMerkleTreeForChain({
   chainId,
   epoch,

--- a/scripts/gas-refund-program/computeMerkleTree.ts
+++ b/scripts/gas-refund-program/computeMerkleTree.ts
@@ -3,6 +3,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 import { computeMerkleData } from './refund/merkle-tree';
 import {
+  fetchLastEpochRefunded,
   merkleRootExists,
   saveMerkleTreeInDB,
 } from './persistance/db-persistance';
@@ -17,6 +18,8 @@ import {
 import { GasRefundTransaction } from '../../src/models/GasRefundTransaction';
 import { saveMerkleTreeInFile } from './persistance/file-persistance';
 import { init, resolveEpochCalcTimeInterval } from './common';
+import { EpochInfo } from '../../src/lib/epoch-info';
+import { CHAIN_ID_MAINNET } from '../../src/lib/constants';
 
 const logger = global.LOGGER('GRP:COMPUTE_MERKLE_TREE');
 
@@ -82,29 +85,41 @@ export async function computeAndStoreMerkleTreeForChain({
 async function startComputingMerkleTreesAllChains() {
   await init();
 
-  const epoch = Number(process.env.GRP_EPOCH) || GasRefundGenesisEpoch; // @TODO: automate
+  const latestEpochRefunded = await fetchLastEpochRefunded();
+  let startEpoch = latestEpochRefunded
+    ? latestEpochRefunded + 1
+    : GasRefundGenesisEpoch;
 
   assert(
-    epoch >= GasRefundGenesisEpoch,
+    startEpoch >= GasRefundGenesisEpoch,
     'cannot compute grp merkle data for epoch < genesis_epoch',
   );
 
-  const { isEpochEnded } = await resolveEpochCalcTimeInterval(epoch);
+  const currentEpoch = EpochInfo.getInstance(
+    CHAIN_ID_MAINNET,
+    true,
+  ).currentEpoch;
 
-  if (!skipCheck)
-    assert(
-      isEpochEnded,
-      `Epoch ${epoch} has not ended or data not available yet`,
+  assert(currentEpoch, 'currentEpoch should defined');
+
+  for (let epoch = startEpoch; epoch <= currentEpoch; epoch++) {
+    const { isEpochEnded } = await resolveEpochCalcTimeInterval(epoch);
+
+    if (!skipCheck && !isEpochEnded) {
+      return logger.warn(
+        `Epoch ${epoch} has not ended or full onchain data not available yet`,
+      );
+    }
+
+    await Promise.all(
+      GRP_SUPPORTED_CHAINS.map(chainId =>
+        computeAndStoreMerkleTreeForChain({
+          chainId,
+          epoch,
+        }),
+      ),
     );
-
-  await Promise.all(
-    GRP_SUPPORTED_CHAINS.map(chainId =>
-      computeAndStoreMerkleTreeForChain({
-        chainId,
-        epoch,
-      }),
-    ),
-  );
+  }
 }
 
 startComputingMerkleTreesAllChains()

--- a/scripts/gas-refund-program/readme.md
+++ b/scripts/gas-refund-program/readme.md
@@ -6,12 +6,13 @@
 - **DATABASE_URL**: Postgres local instance
 
 Start local postgres:
-`docker run --name volume-tracker-db -e POSTGRES_PASSWORD=paraswap -e POSTGRES_USER=paraswap -e POSTGRES_DB=volume_tracker -p 32780:5432 -d postgres`
-
+`docker compose up -d` in src/ folder
+or
+`docker run --name volume-tracker-db -e POSTGRES_PASSWORD=paraswap -e POSTGRES_USER=paraswap -e POSTGRES_DB=volume_tracker -p 32780:5432 -d postgres` anywhere
 
 ## Description
 
-- **computeGasRefund**: index transactions over one epoch and compute refund (`sum(gas * gasPrice * pspChainCurrencySameDayRate * refundPercent)` -> will soon run automatically/periodically
+- **computeGasRefund**: index transactions over one epoch and compute refund (`sum(gas * gasPrice * pspChainCurrencySameDayRate * refundPercent)` -> run automatically/periodically
 - **computeMerkleTree**: compute merkle tree of all gas refunds and store in file/db -> 2 variants needed to seed contract upfront then allow users to actually claim read next section
 
 ## Run the scripts

--- a/scripts/gas-refund-program/staking/abstract-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/abstract-stakes-tracker.ts
@@ -1,14 +1,36 @@
 import BigNumber from 'bignumber.js';
+import { assert } from 'ts-essentials';
 
 export class AbstractStakesTracker {
   startBlock: number;
   endBlock: number;
+  startTimestamp: number;
+  endTimestamp: number;
 
-  setBlockBoundary(startBlock: number, endBlock: number) {
+  setBlockBoundary({
+    startBlock,
+    endBlock,
+    startTimestamp,
+    endTimestamp,
+  }: {
+    startBlock: number;
+    endBlock: number;
+    startTimestamp: number;
+    endTimestamp: number;
+  }) {
     this.startBlock = startBlock;
     this.endBlock = endBlock;
+    this.startTimestamp = startTimestamp;
+    this.endTimestamp = endTimestamp;
 
     return this;
+  }
+
+  assertTimestampWithinLoadInterval(timestamp: number) {
+    assert(
+      timestamp >= this.startTimestamp && timestamp <= this.endTimestamp,
+      'timestamp is out of range',
+    );
   }
 }
 

--- a/scripts/gas-refund-program/staking/safety-module-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/safety-module-stakes-tracker.ts
@@ -396,6 +396,8 @@ export default class SafetyModuleStakesTracker
 
   // @FIXME: current formula assumes all PSP in the balancer pool are detained by stkPSPBpt. Fix background compat
   computeStakedPSPBalance(account: string, timestamp: number) {
+    this.assertTimestampWithinLoadInterval(timestamp);
+
     const stkPSPBPT = reduceTimeSeries(
       timestamp,
       this.initState.stkPSPBptUsersBalances[account],
@@ -407,6 +409,8 @@ export default class SafetyModuleStakesTracker
   }
 
   computeStakedPSPBalanceWithVirtualLockup(account: string, timestamp: number) {
+    this.assertTimestampWithinLoadInterval(timestamp);
+
     const startOfVirtualLockupPeriod = timestamp - VIRTUAL_LOCKUP_PERIOD;
 
     const stakeAtStartOfVirtualLockup = reduceTimeSeries(

--- a/scripts/gas-refund-program/staking/safety-module-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/safety-module-stakes-tracker.ts
@@ -409,9 +409,10 @@ export default class SafetyModuleStakesTracker
   }
 
   computeStakedPSPBalanceWithVirtualLockup(account: string, timestamp: number) {
-    this.assertTimestampWithinLoadInterval(timestamp);
-
     const startOfVirtualLockupPeriod = timestamp - VIRTUAL_LOCKUP_PERIOD;
+
+    this.assertTimestampWithinLoadInterval(timestamp);
+    this.assertTimestampWithinLoadInterval(startOfVirtualLockupPeriod);
 
     const stakeAtStartOfVirtualLockup = reduceTimeSeries(
       startOfVirtualLockupPeriod,

--- a/scripts/gas-refund-program/staking/spsp-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/spsp-stakes-tracker.ts
@@ -382,6 +382,8 @@ export default class SPSPStakesTracker
   }
 
   computeStakedPSPBalance(account: string, timestamp: number) {
+    this.assertTimestampWithinLoadInterval(timestamp);
+
     const totalPSPBalance = SPSPAddresses.reduce((acc, poolAddress) => {
       const sPSPAmount = reduceTimeSeries(
         timestamp,
@@ -415,6 +417,8 @@ export default class SPSPStakesTracker
     timestamp: number,
     endTimestamp: number,
   ) {
+    this.assertTimestampWithinLoadInterval(timestamp);
+
     const account = _account.toLowerCase();
 
     const startOfHourTimestampUnix = startOfHourSec(timestamp);
@@ -444,6 +448,8 @@ export default class SPSPStakesTracker
     account: string,
     timestamp: number,
   ) {
+    this.assertTimestampWithinLoadInterval(timestamp);
+
     const totalPSPBalance = SPSPAddresses.reduce((acc, poolAddress) => {
       const sPSPAmount = reduceTimeSeries(
         timestamp,
@@ -488,6 +494,8 @@ export default class SPSPStakesTracker
   }
 
   computeStakedPSPBalanceWithVirtualLockup(account: string, timestamp: number) {
+    this.assertTimestampWithinLoadInterval(timestamp);
+
     const totalPSPBalance = SPSPAddresses.reduce((acc, poolAddress) => {
       const startOfVirtualLockupPeriod = timestamp - VIRTUAL_LOCKUP_PERIOD;
 

--- a/scripts/gas-refund-program/staking/spsp-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/spsp-stakes-tracker.ts
@@ -494,11 +494,12 @@ export default class SPSPStakesTracker
   }
 
   computeStakedPSPBalanceWithVirtualLockup(account: string, timestamp: number) {
+    const startOfVirtualLockupPeriod = timestamp - VIRTUAL_LOCKUP_PERIOD;
+
     this.assertTimestampWithinLoadInterval(timestamp);
+    this.assertTimestampWithinLoadInterval(startOfVirtualLockupPeriod);
 
     const totalPSPBalance = SPSPAddresses.reduce((acc, poolAddress) => {
-      const startOfVirtualLockupPeriod = timestamp - VIRTUAL_LOCKUP_PERIOD;
-
       const stakeAtStartOfVirtualLockup = reduceTimeSeries(
         startOfVirtualLockupPeriod,
         this.initState.sPSPBalanceByAccount[poolAddress][account],

--- a/scripts/gas-refund-program/staking/stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/stakes-tracker.ts
@@ -7,7 +7,6 @@ import {
   GasRefundSafetyModuleStartEpoch,
   GasRefundSPSPStakesAlgoFlipEpoch,
   GasRefundVirtualLockupStartEpoch,
-  VIRTUAL_LOCKUP_PERIOD,
 } from '../../../src/lib/gas-refund';
 import { OFFSET_CALC_TIME, SCRIPT_START_TIME_SEC } from '../common';
 import { getLatestEpochRefundedAllChains } from '../persistance/db-persistance';
@@ -77,10 +76,20 @@ export default class StakesTracker {
 
     await Promise.all([
       SPSPStakesTracker.getInstance()
-        .setBlockBoundary(startBlockSPSP, endBlock)
+        .setBlockBoundary({
+          startBlock: startBlockSPSP,
+          endBlock,
+          startTimestamp: startTimeSPSP,
+          endTimestamp: endTime,
+        })
         .loadStakes(),
       SafetyModuleStakesTracker.getInstance()
-        .setBlockBoundary(startBlockSM, endBlock)
+        .setBlockBoundary({
+          startBlock: startBlockSM,
+          endBlock,
+          startTimestamp: startTimeSM,
+          endTimestamp: endTime,
+        })
         .loadStakes(),
     ]);
   }

--- a/src/lib/gas-refund-api.ts
+++ b/src/lib/gas-refund-api.ts
@@ -29,7 +29,6 @@ interface MerkleRedeem extends Contract {
 }
 
 const MerkleRedeemAddress: { [chainId: number]: string } = {
-  // @TODO
   [CHAIN_ID_MAINNET]: '0xFEB7e2D8584BEf7BB21dA0B70C148DABf1388031',
   [CHAIN_ID_POLYGON]: '0xD15Fe65BCf0B612343E879434dc72DB1721F732D',
   [CHAIN_ID_FANTOM]: '0xCA82162e3666dbDf97814197Ae82731D857125dE',


### PR DESCRIPTION
+ Tests for https://github.com/paraswap/paraswap-volume-tracker/pull/58
+ assertions to verify that for every tx we observe, its timestamp is in the load stake interval
+ small change to `gas-refund:compute-merkle-tree-save-db` script to compute merkle trees in a loop