### PR TITLE
fix/safety-module-psp-balance

### DIFF
--- a/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
+++ b/__tests__/gas-refund-program/safety-module-stakes-tracker.ts
@@ -35,7 +35,7 @@ describe('SafetyModuleStakesTracker', () => {
     });
 
     test('Staked PSP Balance at timestamp', () => {
-      const pspBalanceAtTimestamp = tracker.computeStakedPSPBalance(
+      const pspBalanceAtTimestamp = tracker.computeStakedPSPBalanceBroken(
         '0x0e71f7a6bbae357a1cd364173ae69d3fb2e539e3',
         1649822860, // timestamp has to be within range
       );
@@ -67,12 +67,15 @@ describe('SafetyModuleStakesTracker', () => {
       const txTimestamp = 1655660833;
       const account = '0x88f81b95eae67461b2d687343d36852f87409a7b';
 
-      const actualStakeAtT = tracker.computeStakedPSPBalance(
+      const actualStakeAtT = tracker.computeStakedPSPBalanceBroken(
         account,
         txTimestamp,
       );
       const virtuallyLockedStakeAtT =
-        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+        tracker.computeStakedPSPBalanceWithVirtualLockupBroken(
+          account,
+          txTimestamp,
+        );
 
       expect(actualStakeAtT.isEqualTo(virtuallyLockedStakeAtT)).toBeTruthy();
     });
@@ -85,12 +88,15 @@ describe('SafetyModuleStakesTracker', () => {
       const txTimestamp = 1657252834;
       const account = '0x4532280a66a0c1c709f7e0c40b14b4dea83253c1';
 
-      const actualStakeAtT = tracker.computeStakedPSPBalance(
+      const actualStakeAtT = tracker.computeStakedPSPBalanceBroken(
         account,
         txTimestamp,
       );
       const virtuallyLockedStakeAtT =
-        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+        tracker.computeStakedPSPBalanceWithVirtualLockupBroken(
+          account,
+          txTimestamp,
+        );
 
       expect(virtuallyLockedStakeAtT.isLessThan(actualStakeAtT)).toBeTruthy();
 
@@ -106,13 +112,16 @@ describe('SafetyModuleStakesTracker', () => {
       const txTimestamp = 1656472361;
       const account = '0xfc44a13ea1a98166ffc0719f83b5f3ee2759c03f';
 
-      const actualStakeAtT = tracker.computeStakedPSPBalance(
+      const actualStakeAtT = tracker.computeStakedPSPBalanceBroken(
         account,
         txTimestamp,
       );
 
       const virtuallyLockedStakeAtT =
-        tracker.computeStakedPSPBalanceWithVirtualLockup(account, txTimestamp);
+        tracker.computeStakedPSPBalanceWithVirtualLockupBroken(
+          account,
+          txTimestamp,
+        );
 
       expect(actualStakeAtT.isEqualTo(virtuallyLockedStakeAtT)).toBeTruthy();
       expect(actualStakeAtT.isZero()).toBeTruthy();

--- a/scripts/gas-refund-program/staking/abstract-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/abstract-stakes-tracker.ts
@@ -61,11 +61,3 @@ export class AbstractStakesTracker {
     );
   }
 }
-
-export interface IStakesTracker {
-  loadStakes: () => Promise<void>;
-  computeStakedPSPBalanceWithVirtualLockup: (
-    account: string,
-    timestamp: number,
-  ) => BigNumber;
-}

--- a/scripts/gas-refund-program/staking/abstract-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/abstract-stakes-tracker.ts
@@ -64,7 +64,6 @@ export class AbstractStakesTracker {
 
 export interface IStakesTracker {
   loadStakes: () => Promise<void>;
-  computeStakedPSPBalance: (account: string, timestamp: number) => BigNumber;
   computeStakedPSPBalanceWithVirtualLockup: (
     account: string,
     timestamp: number,

--- a/scripts/gas-refund-program/staking/safety-module-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/safety-module-stakes-tracker.ts
@@ -61,7 +61,7 @@ const bVaultContract = new Contract(
   Provider.getJsonRpcProvider(CHAIN_ID_MAINNET),
 ) as BVaultContract;
 
-const bptAsEERC20 = new Contract(
+const bptAsERC20 = new Contract(
   Balancer_80PSP_20WETH_address,
   ERC20ABI,
   Provider.getJsonRpcProvider(CHAIN_ID_MAINNET),
@@ -97,12 +97,16 @@ interface Swap extends Event {
 type InitState = {
   bptPoolPSPBalance: BigNumber;
   bptPoolTotalSupply: BigNumber;
+  stkPSPBPtTotalSupply: BigNumber;
+  bptBalanceOfStkPSPBpt: BigNumber;
   stkPSPBptUsersBalances: { [address: string]: BigNumber };
 };
 
 type DiffState = {
   bptPoolPSPBalance: TimeSeries;
   bptPoolTotalSupply: TimeSeries;
+  stkPSPBPtTotalSupply: TimeSeries;
+  bptBalanceOfStkPSPBpt: TimeSeries;
   stkPSPBptUsersBalances: { [address: string]: TimeSeries };
 };
 
@@ -114,11 +118,15 @@ export default class SafetyModuleStakesTracker
     stkPSPBptUsersBalances: {},
     bptPoolPSPBalance: ZERO_BN,
     bptPoolTotalSupply: ZERO_BN,
+    stkPSPBPtTotalSupply: ZERO_BN,
+    bptBalanceOfStkPSPBpt: ZERO_BN,
   };
   differentialStates: DiffState = {
     stkPSPBptUsersBalances: {},
     bptPoolPSPBalance: [],
     bptPoolTotalSupply: [],
+    stkPSPBPtTotalSupply: [],
+    bptBalanceOfStkPSPBpt: [],
   };
 
   static instance: SafetyModuleStakesTracker;
@@ -154,15 +162,20 @@ export default class SafetyModuleStakesTracker
           ({
             bptTotalSupply,
             pspBalance,
-
-            //stkPSPBPtTotalSupply, // FIXME: see computeStakedPSPBalance
-            //bptBalanceOfStkPSPBpt, // FIXME: see computeStakedPSPBalance
+            stkPSPBPtTotalSupply,
+            bptBalanceOfStkPSPBpt,
           }) => {
             this.initState.bptPoolTotalSupply = new BigNumber(
               bptTotalSupply.toString(),
             );
             this.initState.bptPoolPSPBalance = new BigNumber(
               pspBalance.toString(),
+            );
+            this.initState.stkPSPBPtTotalSupply = new BigNumber(
+              stkPSPBPtTotalSupply.toString(),
+            );
+            this.initState.bptBalanceOfStkPSPBpt = new BigNumber(
+              bptBalanceOfStkPSPBpt.toString(),
             );
           },
         ),
@@ -173,6 +186,7 @@ export default class SafetyModuleStakesTracker
     return Promise.all([
       this.resolveStkPSPBptChanges(),
       this.resolveBPTPoolSupplyChanges(),
+      this.resolveBPTBalanceOfStkPSPBptChanges(),
       this.resolveBPTPoolPSPBalanceChangesFromLP(),
       this.resolveBPTPoolPSPBalanceChangesFromSwaps(),
     ]);
@@ -196,6 +210,7 @@ export default class SafetyModuleStakesTracker
       const to = e.args[1].toLowerCase();
       const amount = new BigNumber(e.args[2].toString());
 
+      // Mint or Burn
       if (from === NULL_ADDRESS || to === NULL_ADDRESS) {
         const isMint = from === NULL_ADDRESS;
 
@@ -214,9 +229,15 @@ export default class SafetyModuleStakesTracker
           value: isMint ? amount : amount.negated(),
         });
 
+        this.differentialStates.stkPSPBPtTotalSupply.push({
+          timestamp,
+          value: isMint ? amount : amount.negated(),
+        });
+
         return;
       }
 
+      // transfering stake between different accounts
       if (!this.differentialStates.stkPSPBptUsersBalances[from])
         this.differentialStates.stkPSPBptUsersBalances[from] = [];
 
@@ -330,13 +351,13 @@ export default class SafetyModuleStakesTracker
   async resolveBPTPoolSupplyChanges() {
     const events = (
       await Promise.all([
-        bptAsEERC20.queryFilter(
-          bptAsEERC20.filters.Transfer(NULL_ADDRESS),
+        bptAsERC20.queryFilter(
+          bptAsERC20.filters.Transfer(NULL_ADDRESS),
           this.startBlock,
           this.endBlock,
         ),
-        bptAsEERC20.queryFilter(
-          bptAsEERC20.filters.Transfer(null, NULL_ADDRESS),
+        bptAsERC20.queryFilter(
+          bptAsERC20.filters.Transfer(null, NULL_ADDRESS),
           this.startBlock,
           this.endBlock,
         ),
@@ -374,8 +395,56 @@ export default class SafetyModuleStakesTracker
     this.differentialStates.bptPoolTotalSupply.sort(timeseriesComparator);
   }
 
-  compute_BPT_to_PSP_Rate(timestamp: number) {
-    const pspBalance = reduceTimeSeries(
+  async resolveBPTBalanceOfStkPSPBptChanges() {
+    const events = (
+      await Promise.all([
+        bptAsERC20.queryFilter(
+          bptAsERC20.filters.Transfer(null, SAFETY_MODULE_ADDRESS), // stake: user -> safety module
+          this.startBlock,
+          this.endBlock,
+        ),
+        bptAsERC20.queryFilter(
+          bptAsERC20.filters.Transfer(SAFETY_MODULE_ADDRESS), // unstake: safety module -> user
+          this.startBlock,
+          this.endBlock,
+        ),
+      ])
+    ).flat() as Transfer[];
+
+    const blockNumToTimestamp = await fetchBlockTimestampForEvents(events);
+
+    const bptBalanceOfStkPSPBptChanges = events.map(e => {
+      const timestamp = blockNumToTimestamp[e.blockNumber];
+      assert(timestamp, 'block timestamp should be defined');
+      assert(e.event === 'Transfer', 'can only be Transfer event');
+
+      const [from, to, amount] = e.args;
+
+      assert(
+        from.toLowerCase() === SAFETY_MODULE_ADDRESS ||
+          to.toLowerCase() === SAFETY_MODULE_ADDRESS,
+        'can only stake or unstake from safety module',
+      );
+
+      const isStake = to.toLowerCase() === SAFETY_MODULE_ADDRESS;
+      const value = new BigNumber(amount.toString());
+
+      return {
+        timestamp,
+        value: isStake ? value : value.negated(),
+      };
+    });
+
+    this.differentialStates.bptBalanceOfStkPSPBpt =
+      this.differentialStates.bptBalanceOfStkPSPBpt.concat(
+        bptBalanceOfStkPSPBptChanges,
+      );
+    this.differentialStates.bptBalanceOfStkPSPBpt.sort(timeseriesComparator);
+  }
+
+  // @broken assumes all PSP in the balancer pool are detained by stkPSPBpt
+  compute_BPT_to_PSP_Rate__broken(timestamp: number) {
+    const bptPoolPSPBalance = reduceTimeSeries(
       timestamp,
       this.initState.bptPoolPSPBalance,
       this.differentialStates.bptPoolPSPBalance,
@@ -386,16 +455,10 @@ export default class SafetyModuleStakesTracker
       this.initState.bptPoolTotalSupply,
       this.differentialStates.bptPoolTotalSupply,
     );
-    return pspBalance.dividedBy(totalSupply);
+    return bptPoolPSPBalance.dividedBy(totalSupply);
   }
 
-  // PSP-BPT / stkPSPbpt = 1 till no slashing
-  compute_StkPSPBPT_to_PSP_Rate(timestamp: number) {
-    return this.compute_BPT_to_PSP_Rate(timestamp);
-  }
-
-  // @FIXME: current formula assumes all PSP in the balancer pool are detained by stkPSPBpt. Fix background compat
-  computeStakedPSPBalance(account: string, timestamp: number) {
+  computeStakedPSPBalanceBroken(account: string, timestamp: number) {
     this.assertTimestampWithinLoadInterval(timestamp);
 
     const stkPSPBPT = reduceTimeSeries(
@@ -403,12 +466,15 @@ export default class SafetyModuleStakesTracker
       this.initState.stkPSPBptUsersBalances[account],
       this.differentialStates.stkPSPBptUsersBalances[account],
     );
-    const stkPSP2PSPRate = this.compute_StkPSPBPT_to_PSP_Rate(timestamp);
+    const stkPSP2PSPRate = this.compute_BPT_to_PSP_Rate__broken(timestamp);
 
     return stkPSPBPT.multipliedBy(stkPSP2PSPRate);
   }
 
-  computeStakedPSPBalanceWithVirtualLockup(account: string, timestamp: number) {
+  computeStakedPSPBalanceWithVirtualLockupBroken(
+    account: string,
+    timestamp: number,
+  ) {
     const startOfVirtualLockupPeriod = timestamp - VIRTUAL_LOCKUP_PERIOD;
 
     this.assertTimestampWithinLoadInterval(timestamp);
@@ -430,10 +496,68 @@ export default class SafetyModuleStakesTracker
     if (minStkPSPBptAmountHoldDuringVirtualLockup.isZero())
       return minStkPSPBptAmountHoldDuringVirtualLockup;
 
-    const stkPSP2PSPRate = this.compute_StkPSPBPT_to_PSP_Rate(timestamp);
+    const stkPSP2PSPRate = this.compute_BPT_to_PSP_Rate__broken(timestamp);
 
     return minStkPSPBptAmountHoldDuringVirtualLockup.multipliedBy(
       stkPSP2PSPRate,
     );
+  }
+
+  computeStakedPSPBalanceWithVirtualLockup(account: string, timestamp: number) {
+    const startOfVirtualLockupPeriod = timestamp - VIRTUAL_LOCKUP_PERIOD;
+
+    this.assertTimestampWithinLoadInterval(timestamp);
+    this.assertTimestampWithinLoadInterval(startOfVirtualLockupPeriod);
+
+    const stakeAtStartOfVirtualLockup = reduceTimeSeries(
+      startOfVirtualLockupPeriod,
+      this.initState.stkPSPBptUsersBalances[account],
+      this.differentialStates.stkPSPBptUsersBalances[account],
+    );
+
+    const minStkPSPBptAmountHoldDuringVirtualLockup =
+      computeMinStakedBalanceDuringVirtualLockup(
+        timestamp,
+        stakeAtStartOfVirtualLockup,
+        this.differentialStates.stkPSPBptUsersBalances[account],
+      );
+
+    if (minStkPSPBptAmountHoldDuringVirtualLockup.isZero()) return ZERO_BN;
+
+    const stkPSPBalance = minStkPSPBptAmountHoldDuringVirtualLockup;
+
+    const bptPoolPSPBalance = reduceTimeSeries(
+      timestamp,
+      this.initState.bptPoolPSPBalance,
+      this.differentialStates.bptPoolPSPBalance,
+    );
+    const bptTotalSupply = reduceTimeSeries(
+      timestamp,
+      this.initState.bptPoolTotalSupply,
+      this.differentialStates.bptPoolTotalSupply,
+    );
+
+    const stkPSPBPtTotalSupply = reduceTimeSeries(
+      timestamp,
+      this.initState.stkPSPBPtTotalSupply,
+      this.differentialStates.stkPSPBPtTotalSupply,
+    );
+    const bptBalanceOfStkPSPBpt = reduceTimeSeries(
+      timestamp,
+      this.initState.bptBalanceOfStkPSPBpt,
+      this.differentialStates.bptBalanceOfStkPSPBpt,
+    );
+
+    // bignumber -> bigint, till whole code get refactoring with bigint
+    const pspStaked =
+      SafetyModuleHelper.getInstance().computePSPStakedInStkPSPBpt({
+        stkPSPBalance: BigInt(stkPSPBalance.toFixed()),
+        bptBalanceOfStkPSPBpt: BigInt(bptBalanceOfStkPSPBpt.toFixed()),
+        pspBalance: BigInt(bptPoolPSPBalance.toFixed()),
+        stkPSPBPtTotalSupply: BigInt(stkPSPBPtTotalSupply.toFixed()),
+        bptTotalSupply: BigInt(bptTotalSupply.toFixed()),
+      });
+
+    return new BigNumber(pspStaked.toString());
   }
 }

--- a/scripts/gas-refund-program/staking/safety-module-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/safety-module-stakes-tracker.ts
@@ -22,10 +22,7 @@ import {
   TimeSeries,
   timeseriesComparator,
 } from '../timeseries';
-import {
-  AbstractStakesTracker,
-  IStakesTracker,
-} from './abstract-stakes-tracker';
+import { AbstractStakesTracker } from './abstract-stakes-tracker';
 import { SafetyModuleHelper } from '../../../src/lib/staking/safety-module-helper';
 import { VIRTUAL_LOCKUP_PERIOD } from '../../../src/lib/gas-refund';
 import { computeMinStakedBalanceDuringVirtualLockup } from './common';
@@ -110,10 +107,7 @@ type DiffState = {
   stkPSPBptUsersBalances: { [address: string]: TimeSeries };
 };
 
-export default class SafetyModuleStakesTracker
-  extends AbstractStakesTracker
-  implements IStakesTracker
-{
+export default class SafetyModuleStakesTracker extends AbstractStakesTracker {
   initState: InitState = {
     stkPSPBptUsersBalances: {},
     bptPoolPSPBalance: ZERO_BN,

--- a/scripts/gas-refund-program/staking/spsp-stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/spsp-stakes-tracker.ts
@@ -15,10 +15,7 @@ import {
   ZERO_BN,
 } from '../../../src/lib/utils/helpers';
 import { reduceTimeSeries, TimeSeries } from '../timeseries';
-import {
-  AbstractStakesTracker,
-  IStakesTracker,
-} from './abstract-stakes-tracker';
+import { AbstractStakesTracker } from './abstract-stakes-tracker';
 import { assert } from 'ts-essentials';
 import {
   SPSPAddresses,
@@ -84,10 +81,7 @@ type DiffState = {
 
 const ONE_UNIT = (10 ** 18).toString();
 
-export default class SPSPStakesTracker
-  extends AbstractStakesTracker
-  implements IStakesTracker
-{
+export default class SPSPStakesTracker extends AbstractStakesTracker {
   initState: InitState = {
     totalSupply: {},
     pspBalance: {},

--- a/scripts/gas-refund-program/staking/stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/stakes-tracker.ts
@@ -1,5 +1,4 @@
 import { assert } from 'ts-essentials';
-import { BlockInfo } from '../../../src/lib/block-info';
 import { CHAIN_ID_MAINNET } from '../../../src/lib/constants';
 import { EpochInfo } from '../../../src/lib/epoch-info';
 import {
@@ -25,11 +24,8 @@ export default class StakesTracker {
   }
 
   async loadHistoricalStakes() {
-    const blockInfo = BlockInfo.getInstance(CHAIN_ID_MAINNET);
     const epochInfo = EpochInfo.getInstance(CHAIN_ID_MAINNET, true);
 
-    // @FIXME: as this has to be aligned with the logic where we scan transactions
-    // we have to come up with a stronger implem to always make sure tx scanning time isn't lower than stakes fetching time
     const latestEpochRefunded = await getLatestEpochRefundedAllChains();
 
     // Note: since we take start of latest epoch refunded, we don't need adjust start times with VIRTUAL_LOCKUP_PERIOD

--- a/scripts/gas-refund-program/staking/stakes-tracker.ts
+++ b/scripts/gas-refund-program/staking/stakes-tracker.ts
@@ -4,6 +4,7 @@ import { CHAIN_ID_MAINNET } from '../../../src/lib/constants';
 import { EpochInfo } from '../../../src/lib/epoch-info';
 import {
   GasRefundGenesisEpoch,
+  GasRefundSafetyModuleAllPSPInBptFixStartEpoch,
   GasRefundSafetyModuleStartEpoch,
   GasRefundSPSPStakesAlgoFlipEpoch,
   GasRefundVirtualLockupStartEpoch,
@@ -97,7 +98,12 @@ export default class StakesTracker {
 
     const pspStakedInSM =
       epoch < GasRefundVirtualLockupStartEpoch
-        ? safetyModuleTracker.computeStakedPSPBalance(account, timestamp)
+        ? safetyModuleTracker.computeStakedPSPBalanceBroken(account, timestamp)
+        : epoch < GasRefundSafetyModuleAllPSPInBptFixStartEpoch
+        ? safetyModuleTracker.computeStakedPSPBalanceWithVirtualLockupBroken(
+            account,
+            timestamp,
+          )
         : safetyModuleTracker.computeStakedPSPBalanceWithVirtualLockup(
             account,
             timestamp,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -80,7 +80,7 @@ export const NATIVE_TOKEN_ADDRESS =
   '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
 export const SAFETY_MODULE_ADDRESS =
-  '0xc8dc2ec5f5e02be8b37a8444a1931f02374a17ab';
+  '0xc8dc2ec5f5e02be8b37a8444a1931f02374a17ab'.toLowerCase();
 
 export const AUGUSTUS_V5_ADDRESS = '0xdef171fe48cf0115b1d80b88dc8eab59176fee57';
 

--- a/src/lib/gas-refund.ts
+++ b/src/lib/gas-refund.ts
@@ -29,6 +29,7 @@ export const GasRefundConsiderContractTXsStartEpoch = 12;
 export const GasRefundPrecisionGlitchRefundedAmountsEpoch = 12;
 export const GasRefundBudgetLimitEpochBasedStartEpoch = 16;
 export const GasRefundVirtualLockupStartEpoch = 17;
+export const GasRefundSafetyModuleAllPSPInBptFixStartEpoch = 20;
 
 interface BaseGasRefundData {
   epoch: number;

--- a/src/lib/staking/safety-module-helper.ts
+++ b/src/lib/staking/safety-module-helper.ts
@@ -210,7 +210,7 @@ export class SafetyModuleHelper {
   computePSPStakedInStkPSPBpt({
     stkPSPBalance,
     bptBalanceOfStkPSPBpt,
-    pspBalance,
+    pspBalance: bptPoolPSPBalance,
     stkPSPBPtTotalSupply,
     bptTotalSupply,
   }: {
@@ -221,7 +221,7 @@ export class SafetyModuleHelper {
     bptTotalSupply: bigint;
   }): bigint {
     const pspStaked =
-      (stkPSPBalance * bptBalanceOfStkPSPBpt * pspBalance) /
+      (stkPSPBalance * bptBalanceOfStkPSPBpt * bptPoolPSPBalance) /
       (stkPSPBPtTotalSupply * bptTotalSupply);
 
     return pspStaked;

--- a/src/lib/staking/safety-module-helper.ts
+++ b/src/lib/staking/safety-module-helper.ts
@@ -191,9 +191,13 @@ export class SafetyModuleHelper {
     const stakesByAccount = Object.entries(stkPSPBalanceByAccount).reduce<
       DataByAccount<bigint>
     >((acc, [address, stkPSPBalance]) => {
-      const pspStaked =
-        (stkPSPBalance * bptBalanceOfStkPSPBpt * pspBalance) /
-        (stkPSPBPtTotalSupply * bptTotalSupply);
+      const pspStaked = this.computePSPStakedInStkPSPBpt({
+        stkPSPBalance,
+        bptBalanceOfStkPSPBpt,
+        pspBalance,
+        stkPSPBPtTotalSupply,
+        bptTotalSupply,
+      });
 
       acc[address] = pspStaked;
 
@@ -201,5 +205,25 @@ export class SafetyModuleHelper {
     }, {});
 
     return stakesByAccount;
+  }
+
+  computePSPStakedInStkPSPBpt({
+    stkPSPBalance,
+    bptBalanceOfStkPSPBpt,
+    pspBalance,
+    stkPSPBPtTotalSupply,
+    bptTotalSupply,
+  }: {
+    stkPSPBalance: bigint;
+    bptBalanceOfStkPSPBpt: bigint;
+    pspBalance: bigint;
+    stkPSPBPtTotalSupply: bigint;
+    bptTotalSupply: bigint;
+  }): bigint {
+    const pspStaked =
+      (stkPSPBalance * bptBalanceOfStkPSPBpt * pspBalance) /
+      (stkPSPBPtTotalSupply * bptTotalSupply);
+
+    return pspStaked;
   }
 }


### PR DESCRIPTION
Address an important (forgotten) [FIXME](https://github.com/paraswap/paraswap-volume-tracker/pull/61/files#diff-a1793a0f150fe879a86a16e14c18717873535f46692e256ffa3d0b6f95c56e7cL397)

:x: Old formula:  used to compute stakes considering all PSP in the balancer pool belong to safety module 
✅ New formula: compute stakes by only considering safety module owned PSP in BPT Pool + slashing resistant 

Why it wasn't a problem:
- stkPSPBpt is ~99.67% holder of bptPool at time of this PR [link](https://etherscan.io/token/0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d#balances) safety module address being `0xc8dc2ec5f5e02be8b37a8444a1931f02374a17ab`
- refund is based on discrete stakes (not linear) 
Note: interesting to see that staked amounts are slightly lower while refundedAmount are unchained ([here](https://www.diffchecker.com/5PJUV99j)) (comparing with actually computed data)

Why it will be problem soon:
- DAO is about to place significant liquidity in same balancer pool as safety module but without staking it in safety module (so no more 99.67%)
-> direct impact: stakes per address would have been accidentally higher




Note: there's no more FIXMEs
