### PR TITLE
skip zero claimable amounts epochs

### DIFF
--- a/src/lib/gas-refund/gas-refund-api.ts
+++ b/src/lib/gas-refund/gas-refund-api.ts
@@ -263,7 +263,7 @@ export class GasRefundApi {
     const { totalClaimable, claims } =
       merkleData.reduce<GasRefundClaimsResponseAcc>(
         (acc, claim) => {
-          if (epochToClaimed[claim.epoch]) return acc;
+          if (epochToClaimed[claim.epoch] || claim.refundedAmountPSP === '0') return acc;
 
           const { refundedAmountPSP, ...rClaim } = claim;
           acc.claims.push({ ...rClaim, amount: refundedAmountPSP });


### PR DESCRIPTION
Skip zero claimable amounts from the response
<img width="1213" alt="Screenshot 2023-03-20 at 12 31 20" src="https://user-images.githubusercontent.com/60445720/226314658-ab11abc8-06eb-4eb0-956d-6adfc5229287.png">

F.x. it will skip epoch 31 for our test account: 
https://api.paraswap.io/staking/gas-refund/user-data/1/0x05182E579FDfCf69E4390c3411D8FeA1fb6467cf