### PR TITLE
gas-refund: add support for optimism

### DIFF
--- a/scripts/gas-refund-program/token-pricing/coingecko.ts
+++ b/scripts/gas-refund-program/token-pricing/coingecko.ts
@@ -2,13 +2,13 @@ import {
   CHAIN_ID_BINANCE,
   CHAIN_ID_FANTOM,
   CHAIN_ID_MAINNET,
+  CHAIN_ID_OPTIMISM,
   CHAIN_ID_POLYGON,
 } from '../../../src/lib/constants';
 import { HistoricalPrice } from '../types';
 import { constructHttpClient } from '../../../src/lib/utils/http-client';
 import { startOfDayMilliSec } from '../../../src/lib/utils/helpers';
 import { assert } from 'ts-essentials';
-
 
 export const coingeckoClient = constructHttpClient({
   axiosConfig: {
@@ -17,7 +17,7 @@ export const coingeckoClient = constructHttpClient({
   },
   rateLimitOptions: {
     maxRPS: undefined, // to override default maxRPS
-    maxRequests: 5, 
+    maxRequests: 5,
     perMilliseconds: 60_000,
   },
 });
@@ -33,6 +33,7 @@ type ChainToCoin = {
 export const CHAIN_TO_COIN_ID: ChainToCoin = {
   [CHAIN_ID_MAINNET]: 'ethereum',
   [CHAIN_ID_BINANCE]: 'binancecoin',
+  [CHAIN_ID_OPTIMISM]: 'ethereum',
   [CHAIN_ID_POLYGON]: 'matic-network',
   [CHAIN_ID_FANTOM]: 'fantom',
 };

--- a/scripts/gas-refund-program/transactions-indexing/swaps-subgraph.ts
+++ b/scripts/gas-refund-program/transactions-indexing/swaps-subgraph.ts
@@ -4,6 +4,7 @@ import {
   CHAIN_ID_BINANCE,
   CHAIN_ID_FANTOM,
   CHAIN_ID_MAINNET,
+  CHAIN_ID_OPTIMISM,
   CHAIN_ID_POLYGON,
 } from '../../../src/lib/constants';
 import {
@@ -82,6 +83,8 @@ query ($number_gte: BigInt, $number_lt: BigInt, $blockHashes: [Bytes!], $first: 
 const SubgraphURLs: { [network: number]: string } = {
   [CHAIN_ID_MAINNET]:
     'https://api.thegraph.com/subgraphs/name/paraswap/paraswap-subgraph',
+  [CHAIN_ID_OPTIMISM]:
+    'https://api.thegraph.com/subgraphs/name/paraswap/paraswap-subgraph-optimism',
   [CHAIN_ID_AVALANCHE]:
     'https://api.thegraph.com/subgraphs/name/paraswap/paraswap-subgraph-avalanche',
   [CHAIN_ID_BINANCE]:

--- a/scripts/gas-refund-program/transactions-indexing/transaction-resolver.ts
+++ b/scripts/gas-refund-program/transactions-indexing/transaction-resolver.ts
@@ -19,6 +19,7 @@ import { GasRefundTransaction } from '../types';
 import {
   GasRefundConsiderContractTXsStartEpoch,
   GasRefundV2EpochFlip,
+  GasRefundV2EpochOptimismFlip,
   getMinStake,
   isMainnetStaking,
 } from '../../../src/lib/gas-refund/gas-refund';
@@ -27,6 +28,7 @@ import {
   CHAIN_ID_GOERLI,
   SAFETY_MODULE_ADDRESS,
   AUGUSTUS_V5_ADDRESS,
+  CHAIN_ID_OPTIMISM,
 } from '../../../src/lib/constants';
 import { getMigrationsTxs } from '../staking/2.0/migrations';
 import { MIGRATION_SEPSP2_100_PERCENT_KEY } from '../staking/2.0/utils';
@@ -71,6 +73,10 @@ export const getContractAddresses = ({
   chainId: number;
   epoch: number;
 }) => {
+  if (chainId == CHAIN_ID_OPTIMISM && epoch < GasRefundV2EpochOptimismFlip) {
+    return [];
+  }
+
   if (epoch < GasRefundConsiderContractTXsStartEpoch)
     return [AUGUSTUS_V5_ADDRESS];
 

--- a/scripts/gas-refund-program/transactions-indexing/transaction-resolver.ts
+++ b/scripts/gas-refund-program/transactions-indexing/transaction-resolver.ts
@@ -98,7 +98,7 @@ export const getAllTXs = async ({
   contractAddress,
 }: GetAllTXsInput): Promise<GasRefundTransaction[]> => {
   // fetch swaps and contract (staking pools, safety module) txs
-  if (contractAddress === AUGUSTUS_V5_ADDRESS)
+  if (contractAddress === AUGUSTUS_V5_ADDRESS && chainId !== CHAIN_ID_OPTIMISM)
     return getSwapTXs({
       epoch,
       chainId,

--- a/src/lib/block-info.ts
+++ b/src/lib/block-info.ts
@@ -5,6 +5,7 @@ import {
   CHAIN_ID_POLYGON,
   CHAIN_ID_FANTOM,
   CHAIN_ID_GOERLI,
+  CHAIN_ID_OPTIMISM,
 } from './constants';
 import { Utils } from './utils';
 import { thegraphClient } from './utils/data-providers-clients';
@@ -14,6 +15,8 @@ const logger = global.LOGGER();
 export const SUBGRAPH_URL: { [network: number]: string } = {
   [CHAIN_ID_MAINNET]:
     'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
+  [CHAIN_ID_OPTIMISM]:
+    'https://api.thegraph.com/subgraphs/name/lyra-finance/optimism-mainnet-blocks',
   [CHAIN_ID_ROPSTEN]:
     'https://api.thegraph.com/subgraphs/name/blocklytics/ropsten-blocks',
   [CHAIN_ID_BINANCE]:

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
 export const CHAIN_ID_MAINNET = 1;
+export const CHAIN_ID_OPTIMISM = 10;
 export const CHAIN_ID_ROPSTEN = 3;
 export const CHAIN_ID_GOERLI = 5;
 export const CHAIN_ID_BINANCE = 56;
@@ -8,6 +9,7 @@ export const CHAIN_ID_FANTOM = 250;
 
 export const PSP_ADDRESS: { [chainId: number]: string } = {
   [CHAIN_ID_MAINNET]: '0xcafe001067cdef266afb7eb5a286dcfd277f3de5',
+  [CHAIN_ID_OPTIMISM]: '0xd3594e879b358f430e20f82bea61e83562d49d48',
   [CHAIN_ID_GOERLI]: '0xd8744453f3f5f64362FB6C52eadD0250Be4f45b2',
   [CHAIN_ID_BINANCE]: '0xcafe001067cdef266afb7eb5a286dcfd277f3de5',
   [CHAIN_ID_FANTOM]: '0xcafe001067cdef266afb7eb5a286dcfd277f3de5',
@@ -30,6 +32,7 @@ export const Web3Provider: { [network: number]: string } = {
   //[CHAIN_ID_ROPSTEN]: process.env.HTTP_PROVIDER_3 || '',
   [CHAIN_ID_GOERLI]:
     process.env.HTTP_PROVIDER_5 || 'https://rpc.ankr.com/eth_goerli',
+  [CHAIN_ID_OPTIMISM]: process.env.HTTP_PROVIDER_10 || '',
   [CHAIN_ID_BINANCE]: process.env.HTTP_PROVIDER_56 || '',
   [CHAIN_ID_POLYGON]: process.env.HTTP_PROVIDER_137 || '',
   [CHAIN_ID_FANTOM]: process.env.HTTP_PROVIDER_250 || '',
@@ -39,6 +42,7 @@ export const Web3Provider: { [network: number]: string } = {
 // TODO: in future we can fetch it from the api directly
 export const AugustusV5Address: { [network: number]: string } = {
   [CHAIN_ID_MAINNET]: '0xdef171fe48cf0115b1d80b88dc8eab59176fee57',
+  [CHAIN_ID_OPTIMISM]: '0xdef171fe48cf0115b1d80b88dc8eab59176fee57',
   [CHAIN_ID_BINANCE]: '0xdef171fe48cf0115b1d80b88dc8eab59176fee57',
   [CHAIN_ID_POLYGON]: '0xdef171fe48cf0115b1d80b88dc8eab59176fee57',
 };
@@ -68,6 +72,7 @@ export const ParaswapApiURL = 'https://apiv5.paraswap.io';
 
 export const MULTICALL_ADDRESS: any = {
   [CHAIN_ID_MAINNET]: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
+  [CHAIN_ID_OPTIMISM]: '0xf9ae5216c5b7096d32bbb114be0c0497ff6fd9cb',
   [CHAIN_ID_GOERLI]: '0xc665bfd44e9382d05c1fa31e426162e5cbe824a2',
   [CHAIN_ID_ROPSTEN]: '0x293405FE3aDefDB94A8A1Ed50873a15C6Cc83BC5',
   [CHAIN_ID_BINANCE]: '0xdc6e2b14260f972ad4e5a31c68294fba7e720701',

--- a/src/lib/gas-refund/gas-refund-api.ts
+++ b/src/lib/gas-refund/gas-refund-api.ts
@@ -33,6 +33,7 @@ interface MerkleRedeem extends Contract {
   };
 }
 
+// FIXME merkle redeem address
 const MerkleRedeemAddress: { [chainId: number]: string } = {
   [CHAIN_ID_MAINNET]: '0xFEB7e2D8584BEf7BB21dA0B70C148DABf1388031',
   [CHAIN_ID_GOERLI]: '0xFEB7e2D8584BEf7BB21dA0B70C148DABf1388031', // mainnet addr used as placeholder

--- a/src/lib/gas-refund/gas-refund.ts
+++ b/src/lib/gas-refund/gas-refund.ts
@@ -4,6 +4,7 @@ import {
   CHAIN_ID_FANTOM,
   CHAIN_ID_GOERLI,
   CHAIN_ID_MAINNET,
+  CHAIN_ID_OPTIMISM,
   CHAIN_ID_POLYGON,
 } from '../constants';
 import { isTruthy } from '../utils';
@@ -13,6 +14,7 @@ export const isMainnetStaking = true; // TODO FIXME move to env var
 export const GRP_SUPPORTED_CHAINS = [
   isMainnetStaking ? undefined : CHAIN_ID_GOERLI,
   CHAIN_ID_MAINNET,
+  CHAIN_ID_OPTIMISM,
   CHAIN_ID_POLYGON,
   CHAIN_ID_BINANCE,
   CHAIN_ID_FANTOM,
@@ -41,6 +43,7 @@ export const GasRefundVirtualLockupStartEpoch = 17;
 export const GasRefundSafetyModuleAllPSPInBptFixStartEpoch = 20;
 export const GasRefundV2EpochFlip = 31;
 export const GasRefundV2EpochPSPEP3Flip = 32;
+export const GasRefundV2EpochOptimismFlip = 34;
 
 interface BaseGasRefundData {
   epoch: number;


### PR DESCRIPTION
~Naive approach does not work as we only refund fees based on `gasCost * optimismGasPrice` where optimismGasPrice is ridiculously low.~ solved in [commit](https://github.com/paraswap/paraswap-volume-tracker/pull/81/commits/e15c72c2270404070f8f743974b442c3878a54fa)