### PR TITLE
fix: return 403 for optimism when hitting legacy staking endpoints

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -7,7 +7,8 @@ import { Claim } from './models/Claim';
 import {
   DEFAULT_CHAIN_ID,
   STAKING_CHAIN_IDS_SET,
-  CHAIN_ID_MAINNET, CHAINS_WITHOUT_PARASWAP_POOLS_SUPPORT,
+  CHAIN_ID_MAINNET,
+  CHAINS_WITHOUT_PARASWAP_POOLS_SUPPORT,
 } from './lib/constants';
 import { GasRefundApi } from './lib/gas-refund/gas-refund-api';
 import { EpochInfo } from './lib/epoch-info';
@@ -89,7 +90,10 @@ export default class Router {
     router.get('/pools/earning/:address/:network?', async (req, res) => {
       try {
         const network = Number(req.params.network || DEFAULT_CHAIN_ID);
-        if (!STAKING_CHAIN_IDS_SET.has(network) || !CHAINS_WITHOUT_PARASWAP_POOLS_SUPPORT.includes(network)) {
+        if (
+          !STAKING_CHAIN_IDS_SET.has(network) ||
+          CHAINS_WITHOUT_PARASWAP_POOLS_SUPPORT.includes(network)
+        ) {
           return res
             .status(403)
             .send({ error: `Unsupported network: ${network}` });
@@ -127,7 +131,10 @@ export default class Router {
           return res.status(403).send({ error: 'epochEndTime is required' });
         const epochEndTime = parseInt(<string>req.query.epochEndTime);
         const network = Number(req.params.network || DEFAULT_CHAIN_ID);
-        if (!STAKING_CHAIN_IDS_SET.has(network) || !CHAINS_WITHOUT_PARASWAP_POOLS_SUPPORT.includes(network)) {
+        if (
+          !STAKING_CHAIN_IDS_SET.has(network) ||
+          CHAINS_WITHOUT_PARASWAP_POOLS_SUPPORT.includes(network)
+        ) {
           return res
             .status(403)
             .send({ error: `Unsupported network: ${network}` });


### PR DESCRIPTION
after [the previous fix](https://github.com/paraswap/paraswap-volume-tracker/pull/89) couple legacy staking endpoints were still failing for mainnet due to wrong conditional
 
<img width="800" alt="Screenshot 2023-08-20 at 23 10 08" src="https://github.com/paraswap/paraswap-volume-tracker/assets/60445720/14a171b7-ae62-4cc8-8121-470e5035c825">
<img width="800" alt="Screenshot 2023-08-20 at 23 10 18" src="https://github.com/paraswap/paraswap-volume-tracker/assets/60445720/fa1a5f8b-dae2-415c-85e5-d888ce844aa9">
