### PR TITLE
Feat/dune

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gas-refund:dump-data-to-file": "patch-package && ts-node scripts/gas-refund-program/dump-data-to-file",
     "gas-refund:produce-grp-data-summary-by-account": "ts-node scripts/gas-refund-program/persistance/produce-grp-data-summary-by-account",
     "gas-refund:generate-dune-query": "patch-package && NODE_ENV=development ts-node scripts/gas-refund-program/generate-dune-query",
+    "gas-refund:index-dune-transactions": "patch-package && NODE_ENV=development NODE_OPTIONS='--max-old-space-size=8200' ts-node scripts/gas-refund-program/index-dune-transactions",
     "test": "jest"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gas-refund:compute-merkle-tree-save-file": "patch-package && SAVE_FILE=true SKIP_CHECKS=false NODE_ENV=development ts-node scripts/gas-refund-program/computeMerkleTree",
     "gas-refund:dump-data-to-file": "patch-package && ts-node scripts/gas-refund-program/dump-data-to-file",
     "gas-refund:produce-grp-data-summary-by-account": "ts-node scripts/gas-refund-program/persistance/produce-grp-data-summary-by-account",
+    "gas-refund:generate-dune-query": "patch-package && NODE_ENV=development ts-node scripts/gas-refund-program/generate-dune-query",
     "test": "jest"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/pg": "^8.6.1",
     "axios": "0.24.0",
     "axios-cache-adapter": "^2.7.3",
+    "axios-curlirize": "1.3.7",
     "axios-rate-limit": "^1.3.0",
     "axios-retry": "^3.2.4",
     "bignumber.js": "9.0.1",

--- a/scripts/gas-refund-program/generate-dune-query.ts
+++ b/scripts/gas-refund-program/generate-dune-query.ts
@@ -1,0 +1,163 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+import '../../src/lib/log4js';
+
+import {
+  getCurrentEpoch,
+  resolveEpochCalcTimeInterval,
+} from '../../src/lib/gas-refund/epoch-helpers';
+import { GRP_SUPPORTED_CHAINS } from '../../src/lib/gas-refund/gas-refund';
+import { getContractAddresses } from './transactions-indexing/transaction-resolver';
+import * as moment from 'moment';
+
+import { MIGRATION_SEPSP2_100_PERCENT_KEY } from './staking/2.0/utils';
+import { isTruthy } from '../../src/lib/utils';
+import { CHAIN_ID_OPTIMISM } from '../../src/lib/constants';
+
+export const CHAIN_ID_TO_DUNE_NETWORK: Record<number, string> = {
+  1: 'ethereum',
+  56: 'bnb',
+  137: 'polygon',
+  250: 'fantom',
+  10: 'optimism',
+  42161: 'arbitrum',
+  43114: 'avalanche-c',
+};
+
+export function timestampToDuneFormatted(timestamp: number) {
+  return `'${moment.unix(timestamp).utc().format('YYYY-MM-DD HH:mm:ss')}'`;
+}
+
+function getContractsByChainId() {
+  const currentEpoch = getCurrentEpoch();
+  const contractAddressesByChainId = Object.fromEntries(
+    GRP_SUPPORTED_CHAINS.map(chainId => [
+      chainId,
+      getContractAddresses({ epoch: currentEpoch, chainId }).filter(
+        address => address !== MIGRATION_SEPSP2_100_PERCENT_KEY,
+      ),
+    ]),
+  );
+  return contractAddressesByChainId;
+}
+
+// @TODO: probably should use some tempating engine here
+async function generateDuneQuery() {
+  const currentEpoch = getCurrentEpoch();
+  const { startCalcTime, endCalcTime } = await resolveEpochCalcTimeInterval(
+    currentEpoch - 1,
+  );
+  const dateFrom = timestampToDuneFormatted(startCalcTime);
+  const dateTo = timestampToDuneFormatted(endCalcTime);
+
+  const conractsByChainId = getContractsByChainId();
+
+  const parts = GRP_SUPPORTED_CHAINS.map(chainId => {
+    const network = CHAIN_ID_TO_DUNE_NETWORK[chainId];
+    const transactionsInvolvingContract = `transactionsInvolvingContract_${network}`;
+    const contracts = conractsByChainId[chainId].join(',');
+
+    const txTableColumns = `
+    block_hash
+from
+gas_price
+hash
+l1_tx_origin
+to
+value
+l1_fee_scalar
+block_number
+block_time
+gas_limit
+gas_used
+index
+l1_block_number
+l1_fee
+l1_gas_price
+l1_gas_used
+l1_timestamp
+max_fee_per_gas
+max_priority_fee_per_gas
+nonce
+priority_fee_per_gas
+success
+type
+block_date`
+      .split(/\n/)
+      .map(s => s.trim())
+      .filter(isTruthy);
+
+    const txTableColumnsPart =
+      chainId === CHAIN_ID_OPTIMISM
+        ? txTableColumns
+            .map(s => `cast(transactions."${s}" as varchar) as "${s}"`)
+            .join(', ')
+        : txTableColumns
+            .map(s =>
+              s.includes('l1_')
+                ? `'n/a' as "${s}"`
+                : `cast(transactions."${s}" as varchar) as "${s}"`,
+            )
+            .join(', ');
+
+    const networkData = `networkData_${network}`;
+    const query = `     
+  
+     ${transactionsInvolvingContract} as (
+       select         
+         tx_hash,
+         max(to) as contract,   
+         max(block_time),
+         max(block_number) as block_number   
+       from
+         ${network}.traces
+       where
+        block_time >= to_timestamp(${dateFrom}, 'yyyy-mm-dd hh24:mi:ss')
+         and block_time <= to_timestamp(${dateTo}, 'yyyy-mm-dd hh24:mi:ss')         
+         and to in (${contracts})
+       group by
+         tx_hash         
+       order by
+         max(block_time) desc
+     ),
+     ${networkData} as (
+   select
+     '${network}' as network, ${chainId} as chainId, ${transactionsInvolvingContract}.contract as contract, ${txTableColumnsPart}
+   from
+     ${transactionsInvolvingContract}
+     left join ${network}.transactions as transactions on ${transactionsInvolvingContract}.block_number = transactions.block_number
+     and ${transactionsInvolvingContract}.tx_hash = transactions.hash
+     and transactions.block_time >= to_timestamp(${dateFrom}, 'yyyy-mm-dd hh24:mi:ss')
+     and block_time <= to_timestamp(${dateTo}, 'yyyy-mm-dd hh24:mi:ss')
+     -- where transactions.success = true     
+     )`;
+
+    return [networkData, query];
+  });
+
+  const queries = parts.map(([, query]) => `${query}`).join(',\n');
+
+  const unionPart = parts
+    .map(([networkData]) => `(select * from ${networkData})`)
+    .join(' UNION \n');
+
+  return `with ${queries} SELECT * from (\n${unionPart}) ORDER BY block_time DESC`;
+}
+
+async function main() {
+  const query = await generateDuneQuery();
+  console.log('________________________________________________');
+  console.log(query);
+  console.log('________________________________________________');
+  console.log('Use the above output here https://dune.com/queries');
+}
+
+main()
+  .then(res => {
+    console.log('script finished', res);
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error('script failed', error);
+    process.exit(1);
+  });

--- a/scripts/gas-refund-program/index-dune-transactions.ts
+++ b/scripts/gas-refund-program/index-dune-transactions.ts
@@ -1,0 +1,122 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+import '../../src/lib/log4js';
+import { sliceCalls } from '../../src/lib/utils/helpers';
+import Database from '../../src/database';
+import { DuneRow, DuneTransaction } from '../../src/models/DuneTransaction';
+
+import * as fs from 'fs';
+
+const tmpDirname = './dune-split-data-temp';
+
+// returns tempFolder
+function readStdinAndSliceIntoTempFolder() {
+  var stdinBuffer = fs.readFileSync(0); // STDIN_FILENO = 0
+
+  const data = JSON.parse(stdinBuffer.toString());
+
+  console.log('data', data);
+
+  // this is from-browser GQL response
+  //const origRows = data.data.get_execution.execution_succeeded.data;
+
+  const origRows = data.result.rows;
+
+  fs.mkdirSync(tmpDirname, { recursive: true });
+
+  sliceCalls({
+    inputArray: origRows,
+    execute: (_rows, sliceIdx) => {
+      require('fs').writeFileSync(
+        `${tmpDirname}/slice-${sliceIdx.toString().padStart(3, '0')}.json`,
+        JSON.stringify(_rows, null, 2),
+      );
+    },
+    sliceLength: 10000,
+  });
+
+  // this is from-browser GQL response
+  // const columns = data.data.get_execution.execution_succeeded.columns;
+  const columns = data.result.metadata.column_names;
+  require('fs').writeFileSync(
+    `${tmpDirname}/_columns.json`,
+    JSON.stringify(columns, null, 2),
+  );
+}
+
+function cleanupTempFolder() {
+  fs.rmSync(tmpDirname, { recursive: true, force: true });
+}
+
+async function loadSlicesIntoDb() {
+  const files = fs
+    .readdirSync(tmpDirname)
+    .filter(file => !!file.match(/slice-\d+.json/));
+
+  await Database.connectAndSync('transform-dune-response');
+  await DuneTransaction.destroy({ truncate: true });
+
+  for (let i = 0; i < files.length; i++) {
+    const filename = files[i];
+    const origRows: DuneRow[] = JSON.parse(
+      fs.readFileSync(`${tmpDirname}/${filename}`).toString(),
+    );
+
+    const rows: Partial<DuneRow>[] = origRows
+      .filter(
+        ({ l1_fee_scalar }: { l1_fee_scalar: string }) =>
+          true || l1_fee_scalar !== 'n/a',
+      )
+      .map(row => ({
+        ...Object.fromEntries(
+          Object.entries(row).map(([key, value]) => [
+            key,
+            value === 'n/a' ? null : value,
+          ]),
+        ),
+        block_timestamp: row.block_time
+          ? Date.parse(row.block_time) / 1000
+          : undefined, // looks like 2023-08-31 22:14:05.000 UTC
+      }));
+
+    const queries = sliceCalls({
+      inputArray: rows,
+      execute: async (_rows, sliceIdx) => {
+        try {
+          await DuneTransaction.bulkCreate(_rows);
+        } catch (e) {
+          // error in bulk? try one by one and find out which row is faulty
+          try {
+            await Promise.all(
+              _rows.map(async row => {
+                try {
+                  const res = await DuneTransaction.bulkCreate([row]);
+                } catch (e) {
+                  // to debug in individual level if smth goes wrong
+                  console.error('failed to insert individual', e);
+
+                  throw e;
+                }
+              }),
+            );
+          } catch (e) {
+            throw e;
+          }
+          throw e;
+        }
+        console.log(`inserted slice ${sliceIdx}. Rows length:`, _rows.length);
+      },
+      sliceLength: 1000,
+    });
+  }
+}
+
+async function main() {
+  readStdinAndSliceIntoTempFolder();
+
+  await loadSlicesIntoDb();
+
+  cleanupTempFolder();
+}
+
+main();

--- a/scripts/gas-refund-program/transactions-indexing/txs-covalent.ts
+++ b/scripts/gas-refund-program/transactions-indexing/txs-covalent.ts
@@ -10,6 +10,7 @@ import {
   GasRefundTransaction,
 } from '../types';
 import { CHAIN_ID_OPTIMISM } from '../../../src/lib/constants';
+import { DuneTransaction } from '../../../src/models/DuneTransaction';
 
 interface GetContractTXsByNetworkInput {
   chainId: number;
@@ -165,4 +166,59 @@ export const covalentGetTXsForContractV3 = async ({
     );
 
   return filteredTxs;
+};
+
+export function duneToCovalentLike(
+  dbTx: DuneTransaction,
+): CovalentTransactionV3 {
+  return {
+    to_address: dbTx.to,
+    tx_hash: dbTx.hash,
+    from_address: dbTx.from,
+    gas_price: parseInt(dbTx.gas_price),
+    gas_spent: dbTx.gas_used,
+    block_height: dbTx.block_number,
+    block_signed_at: new Date(Date.parse(dbTx.block_time))
+      .toISOString()
+      .replace(/\.\d+Z$/, 'Z'),
+    fees_paid: (
+      BigInt(dbTx.gas_used) * BigInt(dbTx.gas_price) +
+      BigInt(dbTx.l1_fee || 0)
+    ).toString(),
+    successful: dbTx.success,
+  };
+}
+
+export const constructCovalentAddressToTransaction = (
+  contract: string,
+  chainId: number,
+) => {
+  return (txCov: CovalentTransactionV3): GasRefundTransaction => {
+    const {
+      tx_hash: txHash,
+      from_address: txOrigin,
+      gas_price: _txGasPrice,
+      gas_spent: txGasUsed,
+      block_height: blockNumber,
+      block_signed_at: blockTimestamp,
+      fees_paid: feesPaidInChainCurrency,
+    } = txCov;
+
+    const timestamp = (new Date(blockTimestamp).getTime() / 1000).toString(); // convert time to unixtime (seconds)
+
+    const txGasPrice =
+      chainId !== CHAIN_ID_OPTIMISM
+        ? _txGasPrice.toString()
+        : (BigInt(feesPaidInChainCurrency) / BigInt(txGasUsed)).toString(); // virtually scaling gasPrice up for optimism to take into account for L1 tx fees submission (dirty fix, shouldn't cause too much troubles)
+
+    return {
+      txHash,
+      txOrigin,
+      txGasPrice,
+      txGasUsed: txGasUsed.toString(),
+      blockNumber: blockNumber.toString(),
+      timestamp,
+      contract,
+    };
+  };
 };

--- a/src/database.ts
+++ b/src/database.ts
@@ -51,7 +51,14 @@ export class Database {
 
     const connectionString = connectionStringParts.join('/');
     this.sequelize = new Sequelize(connectionString, {
-      logging: IS_DEV ? msg => logger.debug(msg) : undefined,
+      logging: IS_DEV
+        ? (
+            msg, // avoid huge insert queries stuffing stdout
+          ) =>
+            logger.debug(
+              msg.includes('INSERT INTO') ? msg.substring(0, 300) : msg,
+            )
+        : undefined,
       models: [__dirname + '/models'],
       // needed locally to connect to docker db
       ...(IS_DEV && {

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -1,16 +1,48 @@
-import { JsonRpcProvider } from '@ethersproject/providers';
+import {
+  JsonRpcBatchProvider,
+  JsonRpcProvider,
+} from '@ethersproject/providers';
 import { Web3Provider } from './constants';
+import { retryDecorator } from 'ts-retry-promise';
 
+const TIMEOUT_MS = 10000;
+const DELAY_MS = 1000;
+const RETRY_ATTEMPTS = 5;
+const logger = global.LOGGER('provider');
 export class Provider {
   static jsonRpcProviders: { [network: number]: JsonRpcProvider } = {};
   static getJsonRpcProvider(network: number): JsonRpcProvider {
     if (!this.jsonRpcProviders[network]) {
       if (!Web3Provider[network])
         throw new Error(`Provider not defined for network ${network}`);
-      this.jsonRpcProviders[network] = new JsonRpcProvider(
-        Web3Provider[network],
+      this.jsonRpcProviders[network] = new JsonRpcBatchProvider({
+        url: Web3Provider[network],
+        timeout: TIMEOUT_MS,
+      });
+      this.jsonRpcProviders[network] = new Proxy(
+        this.jsonRpcProviders[network],
+        {
+          get: (target, prop) => {
+            if (prop === 'send') {
+              const fn = Reflect.get(target, prop).bind(target);
+              return async function send(
+                ...args: Parameters<JsonRpcBatchProvider['send']>
+              ) {
+                return retryDecorator(fn, {
+                  retries: RETRY_ATTEMPTS,
+                  delay: DELAY_MS,
+                  logger: msg => {
+                    logger.warn(msg.substring(0, 200));
+                  },
+                })(...args);
+              };
+            }
+            return Reflect.get(target, prop);
+          },
+        },
       );
     }
+
     return this.jsonRpcProviders[network];
   }
 }

--- a/src/lib/utils/covalent.ts
+++ b/src/lib/utils/covalent.ts
@@ -157,8 +157,9 @@ export interface CovalentTransactionV3 {
   gas_price: number;
   block_height: number;
   block_signed_at: string;
-  gas_spent: string;
+  gas_spent: number;
   fees_paid: string;
+  successful: boolean;
 }
 
 interface MinBulkTimeBucketTxsResponse {

--- a/src/lib/utils/http-client.ts
+++ b/src/lib/utils/http-client.ts
@@ -6,6 +6,8 @@ import axiosRetry, {
 } from 'axios-retry';
 import * as _rateLimit from 'axios-rate-limit';
 import { IAxiosCacheAdapterOptions, setupCache } from 'axios-cache-adapter';
+// @ts-ignore // was yelling at missing types, then an issue with ES mods
+const axiosCurlirize = require('axios-curlirize');
 
 type rateLimitOptions = {
   maxRequests?: number;
@@ -76,6 +78,8 @@ export const constructHttpClient = (options?: Options) => {
     shouldResetTimeout: true,
     ...(options?.retryOptions || {}),
   });
+
+  if (process.env.NODE_ENV === 'development') axiosCurlirize(client);
 
   return client;
 };

--- a/src/models/DuneTransaction.ts
+++ b/src/models/DuneTransaction.ts
@@ -1,0 +1,139 @@
+import {
+  Table,
+  Model,
+  Column,
+  PrimaryKey,
+  DataType,
+  AutoIncrement,
+} from 'sequelize-typescript';
+
+import {
+  DataType_ADDRESS,
+  DataType_KECCAK256_HASHED_VALUE,
+} from '../lib/sql-data-types';
+
+export type DuneRow = Partial<{
+  network: string;
+  chainId: number;
+  contract: string;
+  block_hash: string;
+  from: string;
+  gas_price: string; // "100000058",
+  hash: string; // "0x2d1ee3a53c73556a730084043664ed85b4786fd6de333c1f8c81b66509360e68",
+  l1_tx_origin: string | null;
+  to: string;
+  value: string;
+  l1_fee_scalar: string;
+  block_number: number;
+  block_time: string;
+
+  block_timestamp: number; // decorated
+
+  gas_limit: number;
+  gas_used: number;
+  index: number;
+  l1_block_number: number;
+  l1_fee: string;
+  l1_gas_price: string;
+  l1_gas_used: number;
+  l1_timestamp: number;
+  max_fee_per_gas: string;
+  max_priority_fee_per_gas: string;
+  nonce: number;
+  priority_fee_per_gas: string;
+  success: boolean;
+  type: string;
+  block_date: string;
+}>;
+
+@Table
+export class DuneTransaction extends Model<DuneRow> {
+  @PrimaryKey
+  @AutoIncrement
+  @Column(DataType.INTEGER)
+  id: number;
+
+  @Column(DataType.INTEGER)
+  chainId: number;
+
+  @Column(DataType_ADDRESS)
+  contract: string;
+
+  @Column(DataType_KECCAK256_HASHED_VALUE)
+  block_hash: string;
+
+  @Column(DataType_ADDRESS)
+  from: string;
+
+  @Column(DataType.DECIMAL)
+  gas_price: string;
+
+  @Column(DataType_KECCAK256_HASHED_VALUE)
+  hash: string;
+
+  @Column(DataType.DECIMAL)
+  l1_tx_origin: string;
+
+  @Column(DataType_ADDRESS)
+  to: string;
+
+  @Column(DataType.DECIMAL)
+  value: string;
+
+  @Column(DataType.DECIMAL)
+  l1_fee_scalar: string;
+
+  @Column(DataType.INTEGER)
+  block_number: number;
+
+  @Column(DataType.STRING)
+  block_time: string;
+
+  @Column(DataType.INTEGER)
+  block_timestamp: number; // decorated
+
+  @Column(DataType.INTEGER)
+  gas_limit: number;
+
+  @Column(DataType.INTEGER)
+  gas_used: number;
+
+  @Column(DataType.INTEGER)
+  index: number;
+
+  @Column(DataType.INTEGER)
+  l1_block_number: number;
+
+  @Column(DataType.DECIMAL)
+  l1_fee: string;
+
+  @Column(DataType.DECIMAL)
+  l1_gas_price: string;
+
+  @Column(DataType.DECIMAL)
+  l1_gas_used: string;
+
+  @Column(DataType.DECIMAL)
+  l1_timestamp: string;
+
+  @Column(DataType.DECIMAL)
+  max_fee_per_gas: string;
+
+  @Column(DataType.DECIMAL)
+  max_priority_fee_per_gas: string;
+
+  @Column(DataType.DECIMAL)
+  nonce: number;
+
+  @Column(DataType.DECIMAL)
+  priority_fee_per_gas: string;
+
+  @Column(DataType.BOOLEAN)
+  success: boolean;
+
+  @Column(DataType.STRING)
+  type: string;
+
+  @Column(DataType.STRING)
+  block_date: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,6 +1788,11 @@ axios-cache-adapter@^2.7.3:
     cache-control-esm "1.0.0"
     md5 "^2.2.1"
 
+axios-curlirize@1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/axios-curlirize/-/axios-curlirize-1.3.7.tgz#0153c51a5af0e92370169daea33f234d588baad1"
+  integrity sha512-csSsuMyZj1dv1fL0zRPnDAHWrmlISMvK+wx9WJI/igRVDT4VMgbf2AVenaHghFLfI1nQijXUevYEguYV6u5hjA==
+
 axios-rate-limit@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/axios-rate-limit/-/axios-rate-limit-1.3.0.tgz#03241d24c231c47432dab6e8234cfde819253c2e"


### PR DESCRIPTION
- makes the process of fetching transactions potentially eligible for gas refunds rely on Dune instead of Covalent and Subgraph 
- adds axios-curlize to make it more obvious what API calls are made during script execution
- adds a draft retry logic (TBC: use default ethers logic) to prevent the script halting too often during development
- adds script that generates dune query (TBC: there should be a better approach, some engine / API / templating lib?)
- adds script for indexing dune transactions pulled from API into a local DB

**Current state**:
- it generates correct roots for the previous distributions, so presumably works correctly
- indexing one epoch takes 300 seconds with Dune (vs > 30 mins previously)
- it took ~8.5K dune credits to fetch the data (on the basic / free plan) 
<img width="854" alt="Screenshot 2023-10-02 at 09 24 01" src="https://github.com/paraswap/paraswap-volume-tracker/assets/60445720/8f8d6068-4c62-4894-967f-fb5a16c54f1e">
