### PR TITLE
don't fetch tx stake data for epochs after latest distribution (i.e. …

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -265,11 +265,12 @@ export default class Router {
             .send({ error: `epochFrom and epochTo params are required` });
 
         try {
+          const latestDistributedEpoch = await loadLatestDistributedEpoch();
           const transactions = await loadTransactionWithByStakeChainData({
             address,
             epochFrom,
-            epochTo,
-          });
+            epochTo: Math.min(epochTo, latestDistributedEpoch) // no need to fetch TXs after latest distributed epoch, cause they won't have stake data attached            
+          });      
 
           const _data = computeAggregatedStakeChainDetails(transactions);
           const data = showTransactions
@@ -284,7 +285,7 @@ export default class Router {
                 }),
               );
 
-          const latestDistributedEpoch = await loadLatestDistributedEpoch();
+          
 
           return res.json({
             latestDistributedEpoch,


### PR DESCRIPTION
fix the bug that was manifesting in the logs like this:
```
[2023-10-24T04:44:44.059] [ERROR] [router] something went wrong TypeError: Cannot convert null to a BigInt
--

The cause of the bug were transactions loaded from the DB that didn't have stake score attached for the current epoch (as it hasn't been computed yet and hence no records in the DB yet)

Fixed it by capping the passed "epochTo" param in the endpoint `/gas-refund/by-network/{address}/{epochFrom}/{epochTo}` with the latest distributed epoch