### PR TITLE
fix: wrong pending claimable on non-staking network (i.e. polygon)

### DIFF
--- a/src/lib/gas-refund/gas-refund-api.ts
+++ b/src/lib/gas-refund/gas-refund-api.ts
@@ -256,11 +256,7 @@ export class GasRefundApi {
     const latestEpochRefunded = await GasRefundDistribution.max<
       number,
       GasRefundDistribution
-    >('epoch', {
-      where: {
-        chainId: this.network,
-      },
-    });
+    >('epoch');
 
     const rawPendingData: PendingRefundRawData[] =
       await Database.sequelize.query(PENDING_DATA_SQL_QUERY, {


### PR DESCRIPTION
fixes wrong `pendingClaimable` returned by `/consolidated/` endpoint on non-staking networks like polygon 