### PR TITLE
fix: by-network response to fixed

### DIFF
--- a/src/lib/gas-refund/multi-staking-utils.ts
+++ b/src/lib/gas-refund/multi-staking-utils.ts
@@ -110,8 +110,8 @@ type BigNumberByEpochByChain = {
 type ComputedAggregatedEpochData = {
   transactionsWithClaimable: TransactionWithCaimableByStakeChain[];
 
-  refundedByChain: { [chainId: number]: BigNumber };
-  claimableByChain: { [chainId: number]: BigNumber };
+  refundedByChain: { [chainId: number]: string };
+  claimableByChain: { [chainId: number]: string };
 };
 type ComputeAggregatedStakeChainDetailsResult = {
   [epoch: number]: ComputedAggregatedEpochData;
@@ -214,7 +214,7 @@ export function computeAggregatedStakeChainDetails(
 }
 
 
-function toFixed<K  extends string | number | symbol>(dictionary: Record<K, BigNumber>) {
+function toFixed<K  extends string | number | symbol>(dictionary: Record<K, BigNumber>): Record<K, string> {
   const entries = Object.entries<BigNumber>(dictionary).map(([k, v]) => [k, v.toFixed()]);
   return Object.fromEntries(entries)
 }

--- a/src/lib/gas-refund/multi-staking-utils.ts
+++ b/src/lib/gas-refund/multi-staking-utils.ts
@@ -203,12 +203,18 @@ export function computeAggregatedStakeChainDetails(
       {
         transactionsWithClaimable: transactionsWithClaimableByEpoch[epoch],
 
-        refundedByChain: refundedByEpochByChain[epoch],
-        claimableByChain: claimableByEpochByChain[epoch],
+        refundedByChain: toFixed(refundedByEpochByChain[epoch]),
+        claimableByChain: toFixed(claimableByEpochByChain[epoch]),
       },
     ];
   });
   const byEpoch = Object.fromEntries(entries);
 
   return byEpoch;
+}
+
+
+function toFixed<K  extends string | number | symbol>(dictionary: Record<K, BigNumber>) {
+  const entries = Object.entries<BigNumber>(dictionary).map(([k, v]) => [k, v.toFixed()]);
+  return Object.fromEntries(entries)
 }


### PR DESCRIPTION
avoid exponential formatting for the numbers returned by by-network endpoint

Before:
```
{
    "latestDistributedEpoch": 39,
    "byEpoch": {
        "39": {
            "refundedByChain": {
                "1": "1.9907806659053619092803e+22",
                "10": "89491073417606143331"
            },
            "claimableByChain": {
                "1": "1.9997269852657731666799e+22",
                "10": "27879813493569328"
            }
        },
        "40": {
            "refundedByChain": {
                "1": "1.20115328670985149803e+22"
            },
            "claimableByChain": {
                "1": "1.2010293679062705145462e+22",
                "10": "1239188035809834779"
            }
        }
    }
}
```

After:
```
{
    "latestDistributedEpoch": 39,
    "byEpoch": {
        "39": {
            "refundedByChain": {
                "1": "19907806659053619092803",
                "10": "89491073417606143331"
            },
            "claimableByChain": {
                "1": "19997269852657731666799",
                "10": "27879813493569328"
            }
        },
        "40": {
            "refundedByChain": {
                "1": "12011532867098514980300"
            },
            "claimableByChain": {
                "1": "12010293679062705145462",
                "10": "1239188035809834779"
            }
        }
    }
}
```