### PR TITLE
fix: don't skip claims of sePSP1 on tracker init; avoid redundant RPC calls

### DIFF
--- a/scripts/gas-refund-program/persistance/db-persistance.ts
+++ b/scripts/gas-refund-program/persistance/db-persistance.ts
@@ -1,7 +1,10 @@
 import BigNumber from 'bignumber.js';
 import { Op, Sequelize } from 'sequelize';
 import { assert } from 'ts-essentials';
-import { CHAIN_ID_OPTIMISM } from '../../../src/lib/constants';
+import {
+  CHAIN_ID_MAINNET,
+  CHAIN_ID_OPTIMISM,
+} from '../../../src/lib/constants';
 import {
   GRP_SUPPORTED_CHAINS,
   GasRefundTransactionData,
@@ -111,6 +114,18 @@ export async function getLatestEpochRefunded(chainId: number): Promise<number> {
       chainId,
     },
   });
+}
+
+export async function loadLastEthereumDistributionFromDb() {
+  const lastRefundedEpochOnMainnet = await getLatestEpochRefunded(
+    CHAIN_ID_MAINNET,
+  );
+  const lastMultichainDistribution =
+    lastRefundedEpochOnMainnet > GasRefundV2EpochOptimismFlip
+      ? lastRefundedEpochOnMainnet
+      : undefined;
+
+  return lastMultichainDistribution;
 }
 
 export async function getLatestEpochRefundedAllChains() {

--- a/scripts/gas-refund-program/staking/2.0/ClaimableSePSP1StateTracker.ts
+++ b/scripts/gas-refund-program/staking/2.0/ClaimableSePSP1StateTracker.ts
@@ -17,6 +17,7 @@ import {
   EPOCH_WHEN_SWITCHED_TO_SE_PSP1,
   MerkleRedeemAddressSePSP1,
 } from '../../../../src/lib/gas-refund/gas-refund-api';
+import { loadEpochToStartFromWithFix } from './fix';
 
 const logger = global.LOGGER('ClaimableSePSP1StateTracker');
 
@@ -206,6 +207,9 @@ export class ClaimableSePSP1StateTracker extends AbstractStateTracker {
     const allParticipantsFromEpoch32ToStartEpoch = Object.keys(
       distributionsFromEpoch32ToStartEpoch,
     );
+
+    const { filterSePSP1ClaimTimeseriesOnInit } =
+      await loadEpochToStartFromWithFix();
     const balance: InitState['balance'] =
       allParticipantsFromEpoch32ToStartEpoch.reduce((acc, account) => {
         acc[account] = reduceTimeSeries(
@@ -213,11 +217,15 @@ export class ClaimableSePSP1StateTracker extends AbstractStateTracker {
           undefined,
           distributionsFromEpoch32ToStartEpoch[account],
         );
-        acc[account].plus(
+        // artificially skip some claims to maintain consitent roots for pre-fix epochs
+        const claimsTimeseriesWithFix = claimsFromEpoch32ToStartEpoch[
+          account
+        ]?.filter(filterSePSP1ClaimTimeseriesOnInit);
+        acc[account] = acc[account].plus(
           reduceTimeSeries(
             this.startTimestamp,
             undefined,
-            claimsFromEpoch32ToStartEpoch[account],
+            claimsTimeseriesWithFix,
           ),
         );
         return acc;

--- a/scripts/gas-refund-program/staking/2.0/fix.ts
+++ b/scripts/gas-refund-program/staking/2.0/fix.ts
@@ -1,0 +1,80 @@
+import * as pMemoize from 'p-memoize';
+import {
+  loadLastEthereumDistributionFromDb,
+  getLatestEpochRefundedAllChains,
+} from '../../persistance/db-persistance';
+import { TimeSeriesItem } from '../../timeseries';
+import { getEpochStartCalcTime } from '../../../../src/lib/gas-refund/epoch-helpers';
+import { assert } from 'ts-essentials';
+
+// details about this fix: https://www.notion.so/Volume-tracker-taking-too-long-to-index-967c2469d913439dbc953266c99da6c8
+
+const LAST_EPOCH_DISTRIBUTED_ON_FANTOM = 35;
+const EPOCH_WHEN_FIX_WAS_APPLIED = 42;
+
+// the fix alters ClaimableSePSP1 logic on initing state in a different way for computation script and for indexing script, so need a reliable way to distinguish
+const IS_COMPUTATION_SCRIPT = process.argv
+  .join('')
+  .includes('computeDistribution');
+assert(
+  IS_COMPUTATION_SCRIPT === !!process.env.DISTRIBUTED_EPOCH,
+  'DISTRIBUTED_EPOCH must be provided for computation script and must not be provided for indexing script',
+);
+
+async function _loadEpochToStartFrom(): Promise<{
+  epochToStartFrom?: number;
+  filterSePSP1ClaimTimeseriesOnInit: (item: TimeSeriesItem) => boolean;
+}> {
+  const [
+    lastEthereumDistribution,
+    // the value that used to be the "starting from" epoch in legacy code. It stuck at # 35 (epoch 5 in the new epoch numbering)  - the last distribution on Fantom
+    legacyLastDistributionPreMultichain,
+  ] = await Promise.all([
+    loadLastEthereumDistributionFromDb(),
+    getLatestEpochRefundedAllChains(),
+  ]);
+
+  const fixIsApplied =
+    lastEthereumDistribution &&
+    lastEthereumDistribution >= EPOCH_WHEN_FIX_WAS_APPLIED - 1;
+
+  if (!lastEthereumDistribution || !fixIsApplied) {
+    // old (pre-fix) epochs driven by legacy logic
+    return {
+      epochToStartFrom: legacyLastDistributionPreMultichain,
+      filterSePSP1ClaimTimeseriesOnInit: () => false, // ignore claims on init state, just like it used to misbehave before the fix
+    };
+  }
+  const LAST_EPOCH_DISTRIBUTED_ON_FANTOM_MS = await getEpochStartCalcTime(
+    LAST_EPOCH_DISTRIBUTED_ON_FANTOM,
+  );
+
+  const EPOCH_WHEN_FIX_WAS_APPLIED_MS = await getEpochStartCalcTime(
+    EPOCH_WHEN_FIX_WAS_APPLIED,
+  );
+
+  if (!lastEthereumDistribution)
+    throw new Error('lastEthereumDistribution is undefined');
+
+  // after-fix epochs
+  return {
+    epochToStartFrom: lastEthereumDistribution + 1, // start from the currently indexed epoch (i.e. next one after the last indexed one)
+
+    // this filter is intended to replicate legacy behaviour for past pre-fix epochs
+    filterSePSP1ClaimTimeseriesOnInit: item => {
+      // if it's root computation script - suppress claims before the epoch of the fix
+      if (IS_COMPUTATION_SCRIPT)
+        return EPOCH_WHEN_FIX_WAS_APPLIED_MS <= item.timestamp;
+
+      // if it's indexing routine - suppress all claims between last distribution on fantom and the epoch of the fix
+      const shouldBeSkipped =
+        LAST_EPOCH_DISTRIBUTED_ON_FANTOM_MS <= item.timestamp &&
+        item.timestamp <= EPOCH_WHEN_FIX_WAS_APPLIED_MS;
+
+      return shouldBeSkipped;
+    },
+  };
+}
+export const loadEpochToStartFromWithFix = pMemoize(_loadEpochToStartFrom, {
+  cacheKey: () => `loadEpochToStartFrom`,
+});

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactionsAllChains.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactionsAllChains.ts
@@ -46,7 +46,7 @@ export async function fetchRefundableTransactionsAllChains() {
         'cannot compute refund data for epoch < genesis_epoch',
       );
 
-      for (let epoch = startEpoch; epoch < getCurrentEpoch(); epoch++) {
+      for (let epoch = startEpoch; epoch <= getCurrentEpoch(); epoch++) {
         const { startCalcTime, endCalcTime } =
           await resolveEpochCalcTimeInterval(epoch);
 


### PR DESCRIPTION
- fixes the bug with skipped sePSP1 claims 
- eliminates redundant RPC calls by fixing "epoch to start from" being too much in the past
- applies a fix for consistent outputs for pre-fix epochs