### PR TITLE
fix: add staker column to tx snapshot, because with batched delta ord…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ states.json
 
 
 scripts/gas-refund-program/*.csv
+
+.ignored

--- a/scripts/gas-refund-program/persistance/db-persistance.ts
+++ b/scripts/gas-refund-program/persistance/db-persistance.ts
@@ -219,6 +219,7 @@ export function composeGasRefundTransactionStakeSnapshots(
       bptTotalSupply: score?.bptTotalSupply || '0',
       bptPSPBalance: score?.bptPSPBalance || '0',
       claimableSePSP1Balance: score?.claimableSePSP1Balance || '0',
+      staker: transaction.address,
     }));
   }
   return [];

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
@@ -77,11 +77,11 @@ function constructTransactionsProcessor({
                 transaction.txGasPrice.toString(),
               ); // in wei
 
-          const currGasUsedUSD =
-          transaction.txGasUsedUSD ? new BigNumber(transaction.txGasUsedUSD) :
-            currGasUsedChainCur
-            .multipliedBy(currencyRate.chainPrice)
-            .dividedBy(10 ** 18); // chaincurrency always encoded in 18decimals
+          const currGasUsedUSD = transaction.txGasUsedUSD
+            ? new BigNumber(transaction.txGasUsedUSD)
+            : currGasUsedChainCur
+                .multipliedBy(currencyRate.chainPrice)
+                .dividedBy(10 ** 18); // chaincurrency always encoded in 18decimals
 
           const currGasFeePSP = currGasUsedChainCur.dividedBy(
             currencyRate.pspToChainCurRate,

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
@@ -77,7 +77,9 @@ function constructTransactionsProcessor({
                 transaction.txGasPrice.toString(),
               ); // in wei
 
-          const currGasUsedUSD = currGasUsedChainCur
+          const currGasUsedUSD =
+          transaction.txGasUsedUSD ? new BigNumber(transaction.txGasUsedUSD) :
+            currGasUsedChainCur
             .multipliedBy(currencyRate.chainPrice)
             .dividedBy(10 ** 18); // chaincurrency always encoded in 18decimals
 

--- a/sequelize/migrations/20241014000000-tx-snapshot-add-staker-column.js
+++ b/sequelize/migrations/20241014000000-tx-snapshot-add-staker-column.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // queryInterface.
+    await queryInterface.addColumn(
+      'GasRefundTransactionStakeSnapshots',
+      'staker',
+      Sequelize.STRING(42),
+    );
+
+    // Drop the 'txChain_txHash_stakeChain' key if it exists -- the old constraint, without staker column.
+    // the new one will be auto-created by modle
+    await queryInterface.removeIndex(
+      'GasRefundTransactionStakeSnapshots',
+      'txChain_txHash_stakeChain',
+    );
+  },
+
+  async down(queryInterface) {
+    queryInterface.removeColumn('GasRefundTransactionStakeSnapshots', 'staker');
+    await queryInterface.removeIndex(
+      'GasRefundTransactionStakeSnapshots',
+      'txChain_txHash_staker_stakeChain',
+    );
+  },
+};

--- a/src/lib/paraswap-v6-stakers-transactions.ts
+++ b/src/lib/paraswap-v6-stakers-transactions.ts
@@ -20,7 +20,7 @@ type ParaswapTransactionData = {
   blocknumber: number; // 58545814,
   blockhash: string; // '0xb1fdf818d10b1b2d97d82ff421972b03e1e04ceafaa5237c8373e705531e4617',
   txhash: string; //'0xca4c03b4e1fc17553706f9b91a3dd7eaa20202927e3ef77aa31dfdfc04ca4b16'
-  delta_fees_usd: null | number
+  delta_fees_usd: null | number;
 };
 function generateObjectsFromData(data: any): ParaswapTransactionData[] {
   // Dynamically extract column names from the 'cols' array
@@ -102,7 +102,7 @@ export async function fetchParaswapV6StakersTransactions(arg0: {
           txGasUsed: item.txgasused.toString(),
           gasSpentInChainCurrencyWei,
           contract: item.augustusaddress,
-          txGasUsedUSD: item.delta_fees_usd || undefined
+          txGasUsedUSD: item.delta_fees_usd || undefined,
         };
       },
     ),

--- a/src/lib/paraswap-v6-stakers-transactions.ts
+++ b/src/lib/paraswap-v6-stakers-transactions.ts
@@ -20,6 +20,7 @@ type ParaswapTransactionData = {
   blocknumber: number; // 58545814,
   blockhash: string; // '0xb1fdf818d10b1b2d97d82ff421972b03e1e04ceafaa5237c8373e705531e4617',
   txhash: string; //'0xca4c03b4e1fc17553706f9b91a3dd7eaa20202927e3ef77aa31dfdfc04ca4b16'
+  delta_fees_usd: null | number
 };
 function generateObjectsFromData(data: any): ParaswapTransactionData[] {
   // Dynamically extract column names from the 'cols' array
@@ -101,6 +102,7 @@ export async function fetchParaswapV6StakersTransactions(arg0: {
           txGasUsed: item.txgasused.toString(),
           gasSpentInChainCurrencyWei,
           contract: item.augustusaddress,
+          txGasUsedUSD: item.delta_fees_usd || undefined
         };
       },
     ),

--- a/src/models/GasRefundTransactionStakeSnapshot.ts
+++ b/src/models/GasRefundTransactionStakeSnapshot.ts
@@ -5,11 +5,15 @@ import {
   createIndexDecorator,
   Table,
 } from 'sequelize-typescript';
-import { DataType_KECCAK256_HASHED_VALUE } from '../lib/sql-data-types';
+import {
+  DataType_ADDRESS,
+  DataType_KECCAK256_HASHED_VALUE,
+} from '../lib/sql-data-types';
 
 export interface GasRefundTransactionStakeSnapshotData {
   transactionChainId: number;
   transactionHash: string;
+  staker: string;
   stakeChainId: number;
   stakeScore: string; // should be computed by JS, not by SQL
   sePSP1Balance: string;
@@ -20,7 +24,7 @@ export interface GasRefundTransactionStakeSnapshotData {
 }
 
 const compositeIndex = createIndexDecorator({
-  name: 'txChain_txHash_stakeChain',
+  name: 'txChain_txHash_staker_stakeChain',
   type: 'UNIQUE',
   unique: true,
 });
@@ -34,6 +38,10 @@ export class GasRefundTransactionStakeSnapshot extends Model<GasRefundTransactio
   @compositeIndex
   @Column(DataType_KECCAK256_HASHED_VALUE)
   transactionHash: string;
+
+  @compositeIndex
+  @Column(DataType_ADDRESS)
+  staker: string;
 
   @compositeIndex
   @Column(DataType.INTEGER)

--- a/src/types-from-scripts.ts
+++ b/src/types-from-scripts.ts
@@ -59,4 +59,5 @@ export interface ExtendedCovalentGasRefundTransaction // is what passed to final
   blockNumber: string;
   contract: string;
   gasSpentInChainCurrencyWei?: string;
+  txGasUsedUSD?: number;
 }


### PR DESCRIPTION
- migration that adds `staker` column to `GasRefundTransactionStakeSnapshots` to support case of a batched delta tx where multiple stakers can participate
- modify related SQL query that joins `GasRefundTransactionStakeSnapshots` accordingly