### PR TITLE
feat: untrack augustus v5; also only mainnet txs are refunded from epoch 56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode
 node_modules
 
 yarn-error.log

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
@@ -12,13 +12,14 @@ import {
   GasRefundV2EpochFlip,
   getRefundPercent,
   getMinStake,
+  GasRefundV3EpochFlip,
 } from '../../../src/lib/gas-refund/gas-refund';
 import { ONE_HOUR_SEC } from '../../../src/lib/utils/helpers';
 import { PriceResolverFn } from '../token-pricing/psp-chaincurrency-pricing';
 import StakesTracker from '../staking/stakes-tracker';
 import { MIGRATION_SEPSP2_100_PERCENT_KEY } from '../staking/2.0/utils';
 import { isTruthy } from '../../../src/lib/utils';
-import { AUGUSTUS_SWAPPERS_V6_OMNICHAIN } from '../../../src/lib/constants';
+import { AUGUSTUS_SWAPPERS_V6_OMNICHAIN, AUGUSTUS_V5_ADDRESS } from '../../../src/lib/constants';
 import { fetchParaswapV6StakersTransactions } from '../../../src/lib/paraswap-v6-stakers-transactions';
 import { ExtendedCovalentGasRefundTransaction } from '../../../src/types-from-scripts';
 import { GasRefundTransactionDataWithStakeScore, TxProcessorFn } from './types';
@@ -167,7 +168,15 @@ export async function fetchRefundableTransactions({
     epoch,
   });
 
-  const allButV6ContractAddresses = getContractAddresses({ epoch, chainId });
+  let allButV6ContractAddresses = getContractAddresses({ epoch, chainId });
+
+  if(epoch >= GasRefundV3EpochFlip){
+    // starting from epoch 57 we no longer refund augustus v5 txs
+    allButV6ContractAddresses = allButV6ContractAddresses.filter(
+      contract => contract !== AUGUSTUS_V5_ADDRESS,
+    );
+  }
+
 
   const processRawTxs = constructTransactionsProcessor({
     chainId,
@@ -176,7 +185,7 @@ export async function fetchRefundableTransactions({
     resolvePrice,
   });
 
-  const allTxsV5AndV6Merged = await Promise.all([
+  const allTxsAndV6Combined = await Promise.all([
     ...allButV6ContractAddresses.map(async contractAddress => {
       assert(contractAddress, 'contractAddress should be defined');
       const lastTimestampProcessed =
@@ -268,7 +277,7 @@ export async function fetchRefundableTransactions({
     }),
   ]);
 
-  const flattened = allTxsV5AndV6Merged.flat();
+  const flattened = allTxsAndV6Combined.flat();
   const withPatches = await addPatches({
     txs: flattened,
     epoch,

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
@@ -19,7 +19,10 @@ import { PriceResolverFn } from '../token-pricing/psp-chaincurrency-pricing';
 import StakesTracker from '../staking/stakes-tracker';
 import { MIGRATION_SEPSP2_100_PERCENT_KEY } from '../staking/2.0/utils';
 import { isTruthy } from '../../../src/lib/utils';
-import { AUGUSTUS_SWAPPERS_V6_OMNICHAIN, AUGUSTUS_V5_ADDRESS } from '../../../src/lib/constants';
+import {
+  AUGUSTUS_SWAPPERS_V6_OMNICHAIN,
+  AUGUSTUS_V5_ADDRESS,
+} from '../../../src/lib/constants';
 import { fetchParaswapV6StakersTransactions } from '../../../src/lib/paraswap-v6-stakers-transactions';
 import { ExtendedCovalentGasRefundTransaction } from '../../../src/types-from-scripts';
 import { GasRefundTransactionDataWithStakeScore, TxProcessorFn } from './types';
@@ -170,13 +173,12 @@ export async function fetchRefundableTransactions({
 
   let allButV6ContractAddresses = getContractAddresses({ epoch, chainId });
 
-  if(epoch >= GasRefundV2PIP55){
-    // starting from epoch 57 we no longer refund augustus v5 txs
+  if (epoch >= GasRefundV2PIP55) {
+    // starting from epoch 56 we no longer refund augustus v5 txs
     allButV6ContractAddresses = allButV6ContractAddresses.filter(
       contract => contract !== AUGUSTUS_V5_ADDRESS,
     );
   }
-
 
   const processRawTxs = constructTransactionsProcessor({
     chainId,

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactions.ts
@@ -12,7 +12,7 @@ import {
   GasRefundV2EpochFlip,
   getRefundPercent,
   getMinStake,
-  GasRefundV3EpochFlip,
+  GasRefundV2PIP55,
 } from '../../../src/lib/gas-refund/gas-refund';
 import { ONE_HOUR_SEC } from '../../../src/lib/utils/helpers';
 import { PriceResolverFn } from '../token-pricing/psp-chaincurrency-pricing';
@@ -170,7 +170,7 @@ export async function fetchRefundableTransactions({
 
   let allButV6ContractAddresses = getContractAddresses({ epoch, chainId });
 
-  if(epoch >= GasRefundV3EpochFlip){
+  if(epoch >= GasRefundV2PIP55){
     // starting from epoch 57 we no longer refund augustus v5 txs
     allButV6ContractAddresses = allButV6ContractAddresses.filter(
       contract => contract !== AUGUSTUS_V5_ADDRESS,

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactionsAllChains.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactionsAllChains.ts
@@ -6,9 +6,8 @@ import {
 import {
   GasRefundGenesisEpoch,
   GasRefundV2EpochOptimismFlip,
-  GasRefundV3EpochFlip,
+  GasRefundV2PIP55,
   GRP_SUPPORTED_CHAINS,
-  GRP_SUPPORTED_CHAINS_V3,
 } from '../../../src/lib/gas-refund/gas-refund';
 
 import {
@@ -17,7 +16,7 @@ import {
   merkleRootExists,
 } from '../persistance/db-persistance';
 import { fetchPricingAndTransactions } from './fetchPricingAndTransactions';
-import { CHAIN_ID_OPTIMISM, ETH_NETWORKS } from '../../../src/lib/constants';
+import { CHAIN_ID_MAINNET, CHAIN_ID_OPTIMISM, ETH_NETWORKS } from '../../../src/lib/constants';
 import { forceEthereumMainnet } from '../../../src/lib/gas-refund/config';
 
 const logger = global.LOGGER('GRP::fetchRefundableTransactionsAllChains');
@@ -26,8 +25,8 @@ export async function fetchRefundableTransactionsAllChains() {
   const lastEthereumDistribution = await loadLastEthereumDistributionFromDb();
 
   const GrpChainsToIterateOver =
-    lastEthereumDistribution && lastEthereumDistribution >= GasRefundV3EpochFlip -1
-      ? GRP_SUPPORTED_CHAINS_V3
+    lastEthereumDistribution && lastEthereumDistribution >= GasRefundV2PIP55 -1
+      ? [CHAIN_ID_MAINNET]
       : GRP_SUPPORTED_CHAINS;
   return Promise.all(
     GrpChainsToIterateOver.map(async chainId => {

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactionsAllChains.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactionsAllChains.ts
@@ -16,7 +16,11 @@ import {
   merkleRootExists,
 } from '../persistance/db-persistance';
 import { fetchPricingAndTransactions } from './fetchPricingAndTransactions';
-import { CHAIN_ID_MAINNET, CHAIN_ID_OPTIMISM, ETH_NETWORKS } from '../../../src/lib/constants';
+import {
+  CHAIN_ID_MAINNET,
+  CHAIN_ID_OPTIMISM,
+  ETH_NETWORKS,
+} from '../../../src/lib/constants';
 import { forceEthereumMainnet } from '../../../src/lib/gas-refund/config';
 
 const logger = global.LOGGER('GRP::fetchRefundableTransactionsAllChains');
@@ -25,7 +29,7 @@ export async function fetchRefundableTransactionsAllChains() {
   const lastEthereumDistribution = await loadLastEthereumDistributionFromDb();
 
   const GrpChainsToIterateOver =
-    lastEthereumDistribution && lastEthereumDistribution >= GasRefundV2PIP55 -1
+    lastEthereumDistribution && lastEthereumDistribution >= GasRefundV2PIP55 - 1
       ? [CHAIN_ID_MAINNET]
       : GRP_SUPPORTED_CHAINS;
   return Promise.all(

--- a/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactionsAllChains.ts
+++ b/scripts/gas-refund-program/transactions-indexing/fetchRefundableTransactionsAllChains.ts
@@ -6,7 +6,9 @@ import {
 import {
   GasRefundGenesisEpoch,
   GasRefundV2EpochOptimismFlip,
+  GasRefundV3EpochFlip,
   GRP_SUPPORTED_CHAINS,
+  GRP_SUPPORTED_CHAINS_V3,
 } from '../../../src/lib/gas-refund/gas-refund';
 
 import {
@@ -22,8 +24,13 @@ const logger = global.LOGGER('GRP::fetchRefundableTransactionsAllChains');
 
 export async function fetchRefundableTransactionsAllChains() {
   const lastEthereumDistribution = await loadLastEthereumDistributionFromDb();
+
+  const GrpChainsToIterateOver =
+    lastEthereumDistribution && lastEthereumDistribution >= GasRefundV3EpochFlip -1
+      ? GRP_SUPPORTED_CHAINS_V3
+      : GRP_SUPPORTED_CHAINS;
   return Promise.all(
-    GRP_SUPPORTED_CHAINS.map(async chainId => {
+    GrpChainsToIterateOver.map(async chainId => {
       const _lastEpochRefunded =
         lastEthereumDistribution ??
         (await getLatestEpochRefunded(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,6 +6,7 @@ export const CHAIN_ID_BINANCE = 56;
 export const CHAIN_ID_POLYGON = 137;
 export const CHAIN_ID_AVALANCHE = 43114;
 export const CHAIN_ID_FANTOM = 250;
+export const CHAIN_ID_BASE = 8453;
 
 export const PSP_ADDRESS: { [chainId: number]: string } = {
   [CHAIN_ID_MAINNET]: '0xcafe001067cdef266afb7eb5a286dcfd277f3de5',
@@ -95,7 +96,7 @@ export const SAFETY_MODULE_ADDRESS =
 
 //All these must be lower-cased!
 export const AUGUSTUS_V5_ADDRESS = '0xdef171fe48cf0115b1d80b88dc8eab59176fee57';
-export const AUGUSTUS_V6_0_ADDRESS = '0x00000000fdac7708d0d360bddc1bc7d097f47439'; 
+export const AUGUSTUS_V6_0_ADDRESS = '0x00000000fdac7708d0d360bddc1bc7d097f47439';
 export const AUGUSTUS_V6_1_ADDRESS = '0x000db803a70511e09da650d4c0506d0000100000';
 export const AUGUSTUS_V6_2_ADDRESS = '0x6a000f20005980200259b80c5102003040001068';
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,7 +6,6 @@ export const CHAIN_ID_BINANCE = 56;
 export const CHAIN_ID_POLYGON = 137;
 export const CHAIN_ID_AVALANCHE = 43114;
 export const CHAIN_ID_FANTOM = 250;
-export const CHAIN_ID_BASE = 8453;
 
 export const PSP_ADDRESS: { [chainId: number]: string } = {
   [CHAIN_ID_MAINNET]: '0xcafe001067cdef266afb7eb5a286dcfd277f3de5',

--- a/src/lib/gas-refund/gas-refund.ts
+++ b/src/lib/gas-refund/gas-refund.ts
@@ -1,6 +1,5 @@
 import BigNumber from 'bignumber.js';
 import {
-  CHAIN_ID_BASE,
   CHAIN_ID_BINANCE,
   CHAIN_ID_FANTOM,
   CHAIN_ID_GOERLI,
@@ -21,17 +20,6 @@ export const GRP_SUPPORTED_CHAINS = [
   CHAIN_ID_BINANCE,
   CHAIN_ID_FANTOM,
 ].filter(isTruthy);
-
-// the txs on these chains are refunded
-export const GRP_SUPPORTED_CHAINS_V3 = [
-  CHAIN_ID_MAINNET
-]
-
-export const GRP_SUPPORTED_CHAINS_STAKING_V3 = new Set([
-  CHAIN_ID_OPTIMISM,
-  CHAIN_ID_MAINNET,
-  CHAIN_ID_BASE
-]);
 
 export const GRP_V2_SUPPORTED_CHAINS_STAKING = new Set([
   CHAIN_ID_OPTIMISM,
@@ -59,7 +47,7 @@ export const GasRefundV2EpochFlip = 31;
 export const GasRefundV2EpochPSPEP3Flip = 32;
 export const GasRefundV2EpochOptimismFlip = 34;
 export const GasRefundV2PIP38 = 38;
-export const GasRefundV3EpochFlip = 57;
+export const GasRefundV2PIP55 = 56;
 
 interface BaseGasRefundData {
   epoch: number;

--- a/src/lib/gas-refund/gas-refund.ts
+++ b/src/lib/gas-refund/gas-refund.ts
@@ -47,6 +47,7 @@ export const GasRefundV2EpochFlip = 31;
 export const GasRefundV2EpochPSPEP3Flip = 32;
 export const GasRefundV2EpochOptimismFlip = 34;
 export const GasRefundV2PIP38 = 38;
+// https://gov.paraswap.network/t/pip-53-streamlining-of-the-staked-psp-incentive-system/1813
 export const GasRefundV2PIP55 = 56;
 
 interface BaseGasRefundData {

--- a/src/lib/gas-refund/gas-refund.ts
+++ b/src/lib/gas-refund/gas-refund.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 import {
+  CHAIN_ID_BASE,
   CHAIN_ID_BINANCE,
   CHAIN_ID_FANTOM,
   CHAIN_ID_GOERLI,
@@ -20,6 +21,17 @@ export const GRP_SUPPORTED_CHAINS = [
   CHAIN_ID_BINANCE,
   CHAIN_ID_FANTOM,
 ].filter(isTruthy);
+
+// the txs on these chains are refunded
+export const GRP_SUPPORTED_CHAINS_V3 = [
+  CHAIN_ID_MAINNET
+]
+
+export const GRP_SUPPORTED_CHAINS_STAKING_V3 = new Set([
+  CHAIN_ID_OPTIMISM,
+  CHAIN_ID_MAINNET,
+  CHAIN_ID_BASE
+]);
 
 export const GRP_V2_SUPPORTED_CHAINS_STAKING = new Set([
   CHAIN_ID_OPTIMISM,
@@ -47,6 +59,7 @@ export const GasRefundV2EpochFlip = 31;
 export const GasRefundV2EpochPSPEP3Flip = 32;
 export const GasRefundV2EpochOptimismFlip = 34;
 export const GasRefundV2PIP38 = 38;
+export const GasRefundV3EpochFlip = 57;
 
 interface BaseGasRefundData {
   epoch: number;

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,8 +17,6 @@ import {
 import { EpochInfo } from './lib/epoch-info';
 import {
   GRP_SUPPORTED_CHAINS,
-  GRP_SUPPORTED_CHAINS_STAKING_V3,
-  GRP_SUPPORTED_CHAINS_V3,
   GRP_V2_SUPPORTED_CHAINS_STAKING,
 } from './lib/gas-refund/gas-refund';
 import { StakingService } from './lib/staking/staking';
@@ -243,9 +241,6 @@ export default class Router {
     );
 
     // NB: this endpoint will return approximate amounts. They will differ from the ones in merkle tree
-    // it's used to feed data to UI sections "Pending Distribution" (estimation of to be distributed amount) and "Accumulated" (esimtation of ongoing epoch)
-
-    // TODO: check: counts Base as stake network when time comes
     router.get(
       '/gas-refund/by-network/:address/:epochFrom/:epochTo',
       async (req, res) => {
@@ -307,12 +302,10 @@ export default class Router {
       async (req, res) => {
         const address = req.params.address.toLowerCase();
 
-        // include both -- legacy and new v3 networks, so that users can claim old refunds
-        const networksToReturnClaims =  Array.from(new Set([...GRP_SUPPORTED_CHAINS,...GRP_SUPPORTED_CHAINS_V3, ...GRP_SUPPORTED_CHAINS_STAKING_V3]))
         try {
           const byNetworkId = Object.fromEntries(
             await Promise.all(
-              networksToReturnClaims.map(async network => {
+              GRP_SUPPORTED_CHAINS.map(async network => {
                 const gasRefundApi = GasRefundApi.getInstance(network);
                 return [
                   network,


### PR DESCRIPTION
V3 staking prep

- untrack augustus v5 txs
- exclude all networks except ethereum from refunded networks 
~- add base as staking chain~