### PR TITLE
DVOPS-276: AWS <> GitHub OIDC

### DIFF
--- a/.github/workflows/build-and-deploy-grp.yml
+++ b/.github/workflows/build-and-deploy-grp.yml
@@ -15,6 +15,10 @@ on:
           - staging
           - orders
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read
+
 concurrency:
   group: ${{ github.event_name }}-${{ github.event.inputs.target_env }}
   cancel-in-progress: true
@@ -31,14 +35,14 @@ jobs:
     steps:
       - name: Generate GitHub App Installation Token
         id: installation-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ env.GITHUB_CICD_APP_APP_ID }}
           private-key: ${{ secrets.CICD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout Composite Actions Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: paraswap/paraswap-github-actions
           ref: master
@@ -52,8 +56,7 @@ jobs:
           deploy_service: false
           repository_sha: ${{ github.sha}}
           event_name: ${{ github.event_name }}
-          authentication_token: ${{ secrets.AUTHENTICATION_KEY }}
-          authorization_token: ${{ secrets.AUTHORIZATION_KEY }}
+          role_to_assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
           data_center: ${{ secrets.DATA_CENTER }}
           dockerfile_location: Dockerfile.grp
           target_env: ${{ github.event.inputs.target_env }}
@@ -61,7 +64,7 @@ jobs:
       # We re-checkout composite actions repository due to a known bug that if composite action does its own checkout, it deletes any previous checkouts
       # thus, the post action fails on not finding the composite action we checked-out. See: https://github.com/actions/runner/issues/1300
       - name: ReCheckout Composite Actions Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: paraswap/paraswap-github-actions
           ref: master

--- a/.github/workflows/build-and-deploy-service.yml
+++ b/.github/workflows/build-and-deploy-service.yml
@@ -15,6 +15,10 @@ on:
           - staging
           - orders
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read
+
 concurrency:
   group: ${{ github.event_name }}-${{ github.event.inputs.target_env }}-service
   cancel-in-progress: true
@@ -31,14 +35,14 @@ jobs:
     steps:
       - name: Generate GitHub App Installation Token
         id: installation-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ env.GITHUB_CICD_APP_APP_ID }}
           private-key: ${{ secrets.CICD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout Composite Actions Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: paraswap/paraswap-github-actions
           ref: master
@@ -51,15 +55,14 @@ jobs:
           service_name: ${{ env.SERVICE_NAME }}
           repository_sha: ${{ github.sha}}
           event_name: ${{ github.event_name }}
-          authentication_token: ${{ secrets.AUTHENTICATION_KEY }}
-          authorization_token: ${{ secrets.AUTHORIZATION_KEY }}
+          role_to_assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
           data_center: ${{ secrets.DATA_CENTER }}
           target_env: ${{ github.event.inputs.target_env }}
 
       # We re-checkout composite actions repository due to a known bug that if composite action does its own checkout, it deletes any previous checkouts
       # thus, the post action fails on not finding the composite action we checked-out. See: https://github.com/actions/runner/issues/1300
       - name: ReCheckout Composite Actions Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: paraswap/paraswap-github-actions
           ref: master


### PR DESCRIPTION
> [!WARNING]  
> merge only after adjusting the paraswap-github-actions repo

# what
Use OIDC to connect to AWS from GitHub Actions instead of long-lived creds

# why
passwordless authentication is the best practice for communicating with AWS in CICD

# related issue
https://linear.app/paraswap/issue/DVOPS-276

# tests
github actions